### PR TITLE
allow undefined default value for optional params - fixes issue #12

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -84,7 +84,7 @@ var BUILT_INS = [Object, Array, String, Number, Boolean];
 
 function normalizeSchema (name, o, props, fullName, env, argv) {
 
-  if (typeof o === 'object' && !Array.isArray(o) && typeof o.default === 'undefined') {
+  if (typeof o === 'object' && !Array.isArray(o) && !('default' in o)) {
     props[name] = {
       properties: {},
     };
@@ -95,6 +95,7 @@ function normalizeSchema (name, o, props, fullName, env, argv) {
   } else if (typeof o !== 'object' || Array.isArray(o) || o === null) {
     o = { default: o };
   }
+
 
   if (typeof o === 'object') {
     props[name] = o;
@@ -202,7 +203,7 @@ function addDefaultValues(schema, c) {
       addDefaultValues(p, kids);
       if (Object.keys(kids).length) c[name] = kids;
     } else {
-      if (!c[name] && typeof p.default !== 'undefined') c[name] = coerce(name, p.default, schema);
+      if (!c[name] && 'default' in p) c[name] = coerce(name, p.default, schema);
     }
   });
 }
@@ -281,19 +282,21 @@ var convict = function convict(def) {
       return JSON.parse(JSON.stringify(this._instance));
     },
     get: function(path) {
-      var o = JSON.parse(JSON.stringify(this._instance));
+      var o = this._instance;
       if (path) {
         var ar = path.split('.');
         while (ar.length) {
           var k = ar.shift();
-          if (typeof o[k] !== undefined) o = o[k];
-          if (o === undefined) break;
+          if (k in o) {
+            o = o[k];
+          } else {
+            throw new Error("cannot find configuration param '" + path + "'");
+          }
         }
       }
-      if (o === undefined) {
-        throw new Error("cannot find configuration param '" + path + "'");
-      }
-      return o;
+      return typeof o !== 'undefined' ?
+        JSON.parse(JSON.stringify(o)) :
+        void 0;
     },
     has: function(path) {
       try {

--- a/test/format-tests.js
+++ b/test/format-tests.js
@@ -88,6 +88,10 @@ describe('convict formats', function() {
           format: 'prime',
           default: 17
         },
+        optional: {
+          format: '*',
+          default: undefined
+        }
       }
     });
 
@@ -122,5 +126,10 @@ describe('convict formats', function() {
         }
       });
     }).should.throw();
+  });
+
+  it('should accept undefined as a default', function() {
+    var val = conf.get('foo.optional');
+    should.equal(val, undefined);
   });
 });


### PR DESCRIPTION
This diverges from the implied assumption that instances are precisely serializable to/from JSON.
We rely on JavaScript object semantics to determine if a value has been declared undefined, as
opposed to being undeclared, information that is lost during serialization.
