### PR TITLE
coerce 'nat' formatted values

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -254,6 +254,7 @@ function coerce(k, v, schema) {
     }
     switch (format) {
     case 'port':
+    case 'nat':
     case 'integer':
     case 'int': v = parseInt(v, 10); break;
     case 'number': v = parseFloat(v); break;

--- a/test/cases/env_types.js
+++ b/test/cases/env_types.js
@@ -9,6 +9,11 @@ exports.conf = {
     format: 'int',
     env: "INT"
   },
+  nat: {
+    default: 333,
+    format: 'nat',
+    env: "NAT"
+  },
   num: {
     default: 10.1,
     format: Number,
@@ -29,6 +34,7 @@ exports.conf = {
 exports.env = {
   BOOL: true,
   INT: 77,
+  NAT: 666,
   NUM: 789.1011,
   ARRAY: "a,b,c",
   OBJECT: '{"foo": "bar"}'

--- a/test/cases/env_types.out
+++ b/test/cases/env_types.out
@@ -1,6 +1,7 @@
 {
   "bool": true,
   "int": 77,
+  "nat": 666,
   "num": 789.1011,
   "array": ["a", "b", "c"],
   "object": {"foo": "bar"}


### PR DESCRIPTION
From [the docs](https://github.com/mozilla/node-convict#coercion): 

> ...values with the format int, nat, port, or Number will become numbers after a straight forward parseInt or parseFloat.

I found that the 'nat' format wasn't being handled.
