### PR TITLE
Update cjson 0.2.1 —> 0.3.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.4.7"
   },
   "dependencies": {
-    "cjson": "0.2.1",
+    "cjson": "0.3.0",
     "validator": "0.4.24",
     "moment": "1.7.2",
     "optimist": "0.5.0"


### PR DESCRIPTION
Update cjson to 0.3.0: cjson now handles parsing with jsonlint. This results in much improved parsing error messages. see: https://github.com/kof/node-cjson/issues/10
