### PR TITLE
Test the correct convict object for the undefined attribute

### DIFF
--- a/test/schema-tests.js
+++ b/test/schema-tests.js
@@ -31,7 +31,7 @@ describe('convict schema file', function() {
     });
 
     it('should not have properties specified with a default of undefined', function() {
-      var val = conf.has('foo.none');
+      var val = conf2.has('foo.none');
       should.equal(val, false);
     });
   });


### PR DESCRIPTION
It looks like the test is running against conf (where foo.none is not listed) rather than conf2 where it is.
