### PR TITLE
String Interpolation for advanced configuration

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -226,7 +226,6 @@ function replaceAll(str, obj){
   var result, str2;
   str2 = str;
   while ((result = findRegex.exec(str2)) != null){
-    console.log("Replacing", result);
     str2 = str2.replace(result[0], stringToRef(obj, result[1]));
   }
 

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -76,6 +76,8 @@ function validate (instance, schema, errors) {
   return errors;
 }
 
+
+
 // helper for checking that a value is in the list of valid options
 function contains (options, x) {
   check(x, 'must be one of the possible values: ' + JSON.stringify(options)).isIn(options);
@@ -205,6 +207,50 @@ function addDefaultValues(schema, c) {
       if (Object.keys(kids).length) c[name] = kids;
     } else {
       if (!c[name] && 'default' in p) c[name] = coerce(name, p.default, schema);
+    }
+  });
+}
+
+function replaceAll(str, obj){
+  //Based on  http://jsfiddle.net/sc0ttyd/q7zyd/ and corresponding stackoverflow post
+  var stringToRef =  function (object, reference) {
+    function arrayDeref(o, ref, i) {
+      return !ref ? o : (o[ref.slice(0, i ? -1 : ref.length)]);
+    }
+    function dotDeref(o, ref) {
+      return !ref ? o : ref.split('[').reduce(arrayDeref, o);
+    }
+    return reference.split('.').reduce(dotDeref, object);
+  };
+  var findRegex = /\$\{(\S+)\}/;
+  var result, str2;
+  str2 = str;
+  while ((result = findRegex.exec(str2)) != null){
+    console.log("Replacing", result);
+    str2 = str2.replace(result[0], stringToRef(obj, result[1]));
+  }
+
+  return str2;
+}
+
+function interpolate(schema, c, parent){
+  if (parent === undefined){
+    parent = c;
+  }
+  Object.keys(schema.properties).forEach(function(name){
+    var p = schema.properties[name];
+    if (p.properties){
+      var kids = c[name] || {};
+      interpolate(p, kids, parent);
+      if (Object.keys(kids).length) c[name] = kids;
+    } else {
+      if (typeof p.format === 'string'){
+        if (!c[name] && 'default' in p)
+          c[name] = coerce(name, p.default, schema);
+        else{
+          c[name] = replaceAll(c[name], parent);
+        }
+      }
     }
   });
 }
@@ -378,6 +424,9 @@ var convict = function convict(def) {
         throw new Error(errBuf);
       }
       return this;
+    },
+    interpolate: function(){
+      interpolate(rv._schema, rv._instance);
     }
   };
 


### PR DESCRIPTION
I'm not sure if this is still within the spirit of node-convict but I needed a simple interpolation for a project. Here's what it does (I can provide/write tests here but it wasn't entirely clear to me where a feature test should go):

If your json file is as follows with the corresponding schema definition -- I'm assuming both properties are "*" types here.
```
{
"property1": "${property2[0]}"
"property2": [ "test" ]
}
```
This will allow you to interpolate the value in property1 key (assuming the load and validation steps have already been performed) so you get:

```
{
 "property1" : "test"
}
```

Everything else will remain the same, this update doesn't affect any existing methods. `interpolate()` method is just adding new functionality.