### PR TITLE
Update moment.js to 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "cjson": "0.3.0",
     "validator": "1.5.1",
-    "moment": "2.3.1",
+    "moment": "2.6.0",
     "optimist": "0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
No more global `moment` in node.js.
