### PR TITLE
update validator to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cjson": "0.3.0",
     "moment": "2.8.3",
     "optimist": "0.6.1",
-    "validator": "1.5.1"
+    "validator": "2.1.0"
   },
   "devDependencies": {
     "istanbul": "0.3.2",


### PR DESCRIPTION
Because of http://nodesecurity.io/advisories/validator_XSS_Filter_Bypass_via_Encoded_URL

The 3.x versions is not backwards compatible, and requires a bit of refactoring to work with.
