### PR TITLE
Hopefully will show coveralls coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
+script: "npm run-script test-travis"
+after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Node-convict
-[![Build status][travis_img_url]][travis_page_url] [![Dependency Status](https://david-dm.org/mozilla/node-convict.svg)](https://david-dm.org/mozilla/node-convict) [![devDependency Status](https://david-dm.org/mozilla/node-convict/dev-status.svg)](https://david-dm.org/mozilla/node-convict#info=devDependencies)
+[![Build status][travis_img_url]][travis_page_url] [![Dependency Status](https://david-dm.org/mozilla/node-convict.svg)](https://david-dm.org/mozilla/node-convict) [![devDependency Status](https://david-dm.org/mozilla/node-convict/dev-status.svg)](https://david-dm.org/mozilla/node-convict#info=devDependencies) [![Coverage Status](https://img.shields.io/coveralls/mozilla/node-convict.svg)](https://coveralls.io/r/mozilla/node-convict)
 
 [travis_img_url]: https://api.travis-ci.org/mozilla/node-convict.svg
 [travis_page_url]: https://travis-ci.org/mozilla/node-convict


### PR DESCRIPTION
Mozilla has already got a coveralls account: https://coveralls.io/r/mozilla . So hopefully the last thing that is needed to have coverall support is to add the Mozilla `node-convict` repository to the list of the "watched" repos.

@zaach could you review this PR please?

Thanks
