### PR TITLE
Add 'varify' browserify transform to support IE9,10

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "depd": "1.0.0",
     "moment": "2.8.4",
     "optimist": "0.6.1",
-    "validator": "3.26.0"
+    "validator": "3.26.0",
+    "varify": "0.1.1"
   },
   "devDependencies": {
     "istanbul": "0.3.5",
@@ -44,5 +45,10 @@
   "licenses": {
     "type": "Apache",
     "url": "https://raw.github.com/mozilla/node-convict/master/LICENSE"
+  },
+  "browserify": {
+    "transform": [
+      "varify"
+    ]
   }
 }


### PR DESCRIPTION
In f4648fc I documented a way to use convict under browserify. That was fine, until trying IE<11, which currently breaks because convict uses `const`.

Fortunately, browserify has [a feature for that](https://github.com/substack/node-browserify#browserifytransform), and a simple browserify transform exists for this specific const→var simplification: [varify](https://www.npmjs.com/package/varify).

* **The good**:
    * Fixes IE9,IE10 compatibility.
    * Only impacts browserify usage (your usage of `const` out of browserify persists, and unit tests impact is null).
* **The bad**:
    * But additional work on convict using other recent features unsupported by IE might re-break it...
    * ... and I don't see an easy way to unit-test this...
    * ... but we can add more transforms when that happens.

Still, that improves the situation now, doesn't hurt, and is using the recommended browserify feature for this specific need, so I think it's worthwhile.