### PR TITLE
Strict Validation Mode Added

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -77,7 +77,7 @@ function validate (instance, schema, errors,strictValidation) {
       return;
     if (p.properties) {
       var kids = instance[name] || {};
-      validate(kids, p, previousErrors);
+      validate(kids, p, previousErrors,strictValidation);
     } else if (! (typeof p.default === 'undefined' &&
                   instance[name] === p.default)) {
       try {

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -66,9 +66,15 @@ types.integer = types.int;
 
 var converters = {};
 
-function validate (instance, schema, errors) {
-  Object.keys(schema.properties).reduce(function(previousErrors, name) {
+function validate (instance, schema, errors,strictValidation) {
+  Object.keys(instance).reduce(function(previousErrors, name) {
     var p = schema.properties[name];
+    if (strictValidation && !p){
+      previousErrors.push(new Error("configuration param '"+name+"' not declared in the schema"));
+      return previousErrors;
+    }
+    if (!p)
+      return;
     if (p.properties) {
       var kids = instance[name] || {};
       validate(kids, p, previousErrors);
@@ -376,8 +382,10 @@ var convict = function convict(def) {
       importArguments(rv);
       return this;
     },
-    validate: function() {
-      var errors = validate(this._instance, this._schema, []);
+    validate: function(options) {
+      options = options || {};
+      options.strict = options.strict || false;
+      var errors = validate(this._instance, this._schema, [],options.strict);
 
       if (errors.length) {
         var errBuf = '';

--- a/test/cases/validation_correct.json
+++ b/test/cases/validation_correct.json
@@ -2,6 +2,9 @@
 	"foo":"hello",
 	"bar":"hello",
 	"nested":{
-		"level1":"testing"
+		"level1":"testing",
+		"level2":{
+			"level3":"somevalue"
+		}
 	}
 }

--- a/test/cases/validation_correct.json
+++ b/test/cases/validation_correct.json
@@ -1,0 +1,7 @@
+{
+	"foo":"hello",
+	"bar":"hello",
+	"nested":{
+		"level1":"testing"
+	}
+}

--- a/test/cases/validation_incorrect.json
+++ b/test/cases/validation_incorrect.json
@@ -1,0 +1,8 @@
+{
+	"foo":"hello",
+	"bar":"hello",
+	"nested":{
+		"level1_1":"undeclared"
+	},
+	"undeclared":"this property is not declared in the schema"
+}

--- a/test/validation-tests.js
+++ b/test/validation-tests.js
@@ -18,6 +18,13 @@ describe('configuration files contain properties not declared in the schema', fu
                 doc: 'testing',
                 format: String,
                 default: 'testing'
+            },
+            level2:{
+                level3:{
+                    doc:'testing',
+                    format:String,
+                    default:'testing'
+                }
             }
         }
     });

--- a/test/validation-tests.js
+++ b/test/validation-tests.js
@@ -1,0 +1,55 @@
+require("must");
+
+describe('configuration files contain properties not declared in the schema', function() {
+    const convict = require("../");
+    var config = convict({
+        foo: {
+            doc: 'testing',
+            format: String,
+            default: 'testing'
+        },
+        bar: {
+            doc: 'testing',
+            format: String,
+            default: 'testing'
+        },
+        nested: {
+            level1: {
+                doc: 'testing',
+                format: String,
+                default: 'testing'
+            }
+        }
+    });
+    it('must not throw, if properties in config file match with the schema', function() {
+        config.loadFile(__dirname + '/cases/validation_correct.json');
+        (function() {
+            config.validate({
+                strict: true
+            });
+        }).must.not.throw();
+    });
+
+    it('must not throw, if the option to check for non schema properties is set to false', function() {
+        config.loadFile(__dirname + '/cases/validation_incorrect.json');
+        (function() {
+            config.validate({
+                strict: false
+            });
+        }).must.not.throw();
+    });
+    it('must not throw, if the option to check for non schema properties is not specified', function() {
+        config.loadFile(__dirname + '/cases/validation_incorrect.json');
+        (function() {
+            config.validate();
+        }).must.not.throw();
+    });
+    it('must throw, if properties in config file do not match the properties declared in the schema', function() {
+        config.loadFile(__dirname + '/cases/validation_incorrect.json');
+        (function() {
+            config.validate({
+                strict: true
+            });
+        }).must.throw();
+    });
+});


### PR DESCRIPTION
1. Added a Strict Validation mode. If set to true, any properties
specified in config files that are not declared in the schema will
result in errors. This is to ensure that the schema and the config
files are in sync. This brings convict further in line with the concept
of a “Schema”. By default the strict mode is set to false.
2. Added test cases for strict mode