### PR TITLE
addFormat supports object arguments as well as function arguments

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -434,9 +434,9 @@ var convict = function convict(def) {
 // A converter function is optional
 convict.addFormat = function(name, validate, coerce) {
   if (typeof name === 'object') {
-    name = name.name;
     validate = name.validate;
     coerce = name.coerce;
+    name = name.name;
   }
   if (typeof validate !== 'function') {
     throw new Error('Validation function for ' + name + ' must be a function.');

--- a/test/format-tests.js
+++ b/test/format-tests.js
@@ -25,6 +25,18 @@ describe('convict formats', function() {
       }
     });
 
+    convict.addFormat({
+      name: 'float-percent',
+      validate: function(val) {
+        if (val !== 0 && (!val || val > 1 || val < 0)) {
+          throw new Error('must be a float between 0 and 1, inclusive');
+        }
+      },
+      coerce: function(val) {
+        return parseFloat(val, 10);
+      }
+    });
+
     conf = convict({
       foo: {
         enum: {
@@ -94,6 +106,10 @@ describe('convict formats', function() {
         primeNumber: {
           format: 'prime',
           default: 17
+        },
+        percentNumber: {
+          format: 'float-percent',
+          default: 0.5
         },
         optional: {
           format: '*',


### PR DESCRIPTION
Now maps arguments from the object before losing the reference to the object in the `convict.addFormat` method.