### PR TITLE
Update package.json 'license' key format

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,10 +49,7 @@
     }
   },
   "bugs": "https://github.com/mozilla/node-convict/issues",
-  "licenses": {
-    "type": "Apache",
-    "url": "https://raw.github.com/mozilla/node-convict/master/LICENSE"
-  },
+  "license": "Apache-2.0",
   "browserify": {
     "transform": [
       "varify"


### PR DESCRIPTION
"Apache-2.0" is the SPDX identifier for the Apache 2.0 license. You can see it on the site here: https://spdx.org/licenses/Apache-2.0.html#licenseText

and you can verify that the URL referenced by that link is the same URL referenced by the 'LICENSE' file.