### PR TITLE
Document and test properties and schema export

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,23 @@ files that are not declared in the schema will result in errors. This is to
 ensure that the schema and the config files are in sync. By default the strict
 mode is set to false.
 
+### config.getProperties()
+
+Exports all the properties (that is the keys and their current values) as JSON.
+
+### config.toString()
+
+Exports all the properties (that is the keys and their current values) as a
+JSON string.
+
+### config.getSchema()
+
+Exports the schema as JSON.
+
+### config.getSchemaString()
+
+Exports the schema as a JSON string.
+
 ## faq
 
 ### [How can I define a configuration property as "required" without providing a default value?](https://github.com/mozilla/node-convict/issues/29)

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -318,15 +318,24 @@ var convict = function convict(def) {
   }
 
   var rv = {
+    getProperties: function() {
+      return JSON.parse(JSON.stringify(this._instance));
+    },
+    root: deprecate.function(function() {
+      return this.getProperties();
+    }, "Use \"getProperties\" method instead"),
     toString: function() {
       return JSON.stringify(this._instance, null, 2);
     },
-    toSchemaString: function() {
+    getSchema: function() {
+      return JSON.parse(JSON.stringify(this._schema));
+    },
+    getSchemaString: function() {
       return JSON.stringify(this._schema, null, 2);
     },
-    root: function() {
-      return JSON.parse(JSON.stringify(this._instance));
-    },
+    toSchemaString: deprecate.function(function() {
+      return this.getSchemaString();
+    }, "Use \"getSchemaString\" method instead"),
     get: function(path) {
       var o = walk(this._instance, path);
       return typeof o !== 'undefined' ?

--- a/test/schema-tests.js
+++ b/test/schema-tests.js
@@ -24,6 +24,120 @@ describe('convict schema file', function() {
     (function() { conf2.validate(); }).must.not.throw();
   });
 
+  it('must export all its properties as JSON', function() {
+    var res = conf.getProperties();
+    res.must.eql({
+      "foo": {
+        "bar": 7,
+        "baz": {
+          "bing": "foo",
+          "name with spaces": {
+            "name_with_underscores": true
+          }
+        }
+      }
+    });
+  });
+
+  it('must export all its properties as JSON (deprecated method)', function() {
+    var res = conf.root();
+      res.must.eql({
+      "foo": {
+        "bar": 7,
+        "baz": {
+          "bing": "foo",
+          "name with spaces": {
+            "name_with_underscores": true
+          }
+        }
+      }
+    });
+  });
+
+  it('must export all its properties as a string', function() {
+    var res = conf.toString();
+    res.must.eql(JSON.stringify({
+      "foo": {
+        "bar": 7,
+        "baz": {
+          "bing": "foo",
+          "name with spaces": {
+            "name_with_underscores": true
+          }
+        }
+      }
+    }, null, 2));
+  });
+
+  it('must export the schema as JSON', function() {
+    var res = conf.getSchema();
+    res.must.eql({
+      "properties": {
+        "foo": {
+          "properties": {
+            "bar": {},
+            "baz": {
+              "properties": {
+                "bing": {},
+                "name with spaces": {
+                  "properties": {
+                    "name_with_underscores": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('must export the schema as a JSON string', function() {
+    var res = conf.getSchemaString();
+    res.must.eql(JSON.stringify({
+      "properties": {
+        "foo": {
+          "properties": {
+            "bar": {},
+            "baz": {
+              "properties": {
+                "bing": {},
+                "name with spaces": {
+                  "properties": {
+                    "name_with_underscores": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }, null, 2));
+  });
+
+  it('must export the schema as a JSON string (deprecated method)', function() {
+    var res = conf.toSchemaString();
+    res.must.eql(JSON.stringify({
+      "properties": {
+        "foo": {
+          "properties": {
+            "bar": {},
+            "baz": {
+              "properties": {
+                "bing": {},
+                "name with spaces": {
+                  "properties": {
+                    "name_with_underscores": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }, null, 2));
+  });
+
   describe('.has()', function() {
     it('must not have undefined properties', function() {
       var val = conf.has('foo.bar.madeup');


### PR DESCRIPTION
This modification also renames the previously undocumented and untested following methods:
* root→getProperties
* toSchemaString→getSchemaString

The renaming was done for clearer intent and consistency in naming. The previous method names are still supported but deprecated.

This change increases coverage 88%→89%