### PR TITLE
v1.0.0 and remove old deprecated formats ipv4 and ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Convict expands on the standard pattern of configuring node.js applications in a
     checking, type checking, custom checking), generating an error report with
     all errors that are found
 * **Comments allowed**: JSON files are loaded with the `cjson` module, so
-    comments are welcome.
+    comments are welcome
 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -271,10 +271,10 @@ collected and thrown at once.
 
 Options: At the moment `strict` is the only available option.
 
-If the `{strict: true}` option is passed, any properties specified in config
-files that are not declared in the schema will result in errors. This is to
-ensure that the schema and the config files are in sync. By default the strict
-mode is set to false.
+If the `strict` option is passed (that is `{strict: true}` is passed), any
+properties specified in config files that are not declared in the schema will
+result in errors. This is to ensure that the schema and the config files are in
+sync. By default the strict mode is set to false.
 
 ### config.getProperties()
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,17 @@ Convict expands on the standard pattern of configuring node.js applications in a
 
 
 ## Features
-* **Loading and merging**: configurations are loaded from disk or inline and merged. JSON files are loaded with `cjson` so comments are welcome.
-* **Environmental variables**: values can be derived from environmental variables
-* **Command-line arguments**: values can also be derived from command-line arguments
-* **Validation**: configurations are validated against your schema, generating an error report with all errors that are found
+
+* **Loading and merging**: configurations are loaded from disk or inline and
+    merged. JSON files are loaded with `cjson` so comments are welcome.
+* **Nested structure**: keys and values can be organized in a tree structure
+* **Environmental variables**: values can be derived from environmental
+    variables
+* **Command-line arguments**: values can also be derived from command-line
+    arguments
+* **Validation**: configurations are validated against your schema (presence
+    checking, type checking, custom checking), generating an error report with
+    all errors that are found
 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Convict expands on the standard pattern of configuring node.js applications in a
 * **Command-line arguments**: values can also be derived from command-line arguments
 * **Validation**: configurations are validated against your schema, generating an error report with all errors that are found
 
+
 ## Install
 ```bash
 npm install convict
@@ -21,13 +22,11 @@ npm install convict
 
 ## Example:
 
-
 An example `config.js`:
 ```javascript
 var convict = require('convict');
 
-// define a schema
-
+// Define a schema
 var conf = convict({
   env: {
     doc: "The applicaton environment.",
@@ -49,15 +48,12 @@ var conf = convict({
   }
 });
 
-
-// load environment dependent configuration
-
+// Load environment dependent configuration
 var env = conf.get('env');
 conf.loadFile('./config/' + env + '.json');
 
-// perform validation
-
-conf.validate();
+// Perform validation
+conf.validate({strict: true});
 
 module.exports = conf;
 ```
@@ -72,7 +68,7 @@ var server = http.createServer(function (req, res) {
   res.end('Hello World\n');
 });
 
-// consume
+// Consume
 server.listen(conf.get('port'), conf.get('ip'), function(x) {
   var addy = server.address();
   console.log('running on http://' + addy.address + ":" + addy.port);
@@ -200,6 +196,7 @@ var conf = convict({
 
 Convict will automatically coerce environmental variables from strings to their proper types when importing them. For instance, values with the format `int`, `nat`, `port`, or `Number` will become numbers after a straight forward `parseInt` or `parseFloat`. `duration` and `timestamp` are also parse and converted into numbers, though they utilize [moment.js](http://momentjs.com/) for date parsing.
 
+
 ## API
 
 ### var config = convict(schema)
@@ -211,7 +208,6 @@ Returns the current value of the `name` property. `name` can use dot notation to
 config.get('database.host');
 
 // or
-
 config.get('database').host;
 ```
 
@@ -225,7 +221,7 @@ config.default('server.port');
 Returns `true` if the property `name` is defined, or `false` otherwise. E.g.:
 ```javascript
 if (config.has('some.property')) {
-  // do something
+  // Do something
 }
 ```
 
@@ -234,7 +230,7 @@ Sets the value of `name` to value. `name` can use dot notation to reference nest
 ```javascript
 config.set('property.that.may.not.exist.yet', 'some value');
 config.get('property.that.may.not.exist.yet');
-// returns "some value"
+// Returns "some value"
 ```
 
 ### config.load(object)
@@ -259,9 +255,12 @@ Or, loading multiple files at once:
 conf.loadFile(process.env.CONFIG_FILES.split(','));
 ```
 
-### config.validate([{strict: true}])
+### config.validate([options])
 
-Validates `config` against the schema used to initialize it. All errors are collected and thrown at once.
+Validates `config` against the schema used to initialize it. All errors are
+collected and thrown at once.
+
+Options: At the moment `strict` is the only available option.
 
 If the `{strict: true}` option is passed, any properties specified in config
 files that are not declared in the schema will result in errors. This is to
@@ -285,7 +284,8 @@ Exports the schema as JSON.
 
 Exports the schema as a JSON string.
 
-## faq
+
+## FAQ
 
 ### [How can I define a configuration property as "required" without providing a default value?](https://github.com/mozilla/node-convict/issues/29)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Convict expands on the standard pattern of configuring node.js applications in a
 ## Features
 
 * **Loading and merging**: configurations are loaded from disk or inline and
-    merged. JSON files are loaded with `cjson` so comments are welcome.
+    merged
 * **Nested structure**: keys and values can be organized in a tree structure
 * **Environmental variables**: values can be derived from environmental
     variables
@@ -20,6 +20,8 @@ Convict expands on the standard pattern of configuring node.js applications in a
 * **Validation**: configurations are validated against your schema (presence
     checking, type checking, custom checking), generating an error report with
     all errors that are found
+* **Comments allowed**: JSON files are loaded with the `cjson` module, so
+    comments are welcome.
 
 
 ## Install

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -43,12 +43,6 @@ var types = {
   ipaddress: function(x) {
     assert(validator.isIP(x), 'must be an IP address');
   },
-  ipv4: deprecate.function(function(x) {
-    assert(validator.isIP(x), 'must be an IP address');
-  }, "There is no IPv4 vs IPv6 addresses checking anymore, use \"ipaddress\" instead."),
-  ipv6: deprecate.function(function(x) {
-    assert(validator.isIP(x), 'must be an IP address');
-  }, "There is no IPv4 vs IPv6 addresses checking anymore, use \"ipaddress\" instead."),
   duration: function(x) {
     var err_msg = 'must be a positive integer or human readable string (e.g. 3000, "5 days")';
     if (validator.isInt(x)) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Lloyd Hilaiel <lloyd@hilaiel.com> (http://lloyd.io)",
   "name": "convict",
   "description": "Unruly configuration management for nodejs",
-  "version": "0.8.2",
+  "version": "1.0.0",
   "homepage": "https://github.com/mozilla/node-convict",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "dependencies": {
     "cjson": "0.3.1",
     "depd": "1.0.1",
-    "moment": "2.10.5",
+    "moment": "2.10.6",
     "optimist": "0.6.1",
-    "validator": "3.41.3",
+    "validator": "3.43.0",
     "varify": "0.1.1"
   },
   "devDependencies": {

--- a/test/format-tests.js
+++ b/test/format-tests.js
@@ -59,14 +59,6 @@ describe('convict formats', function() {
           format: 'ipaddress',
           default: '127.0.0.1'
         },
-        host2: {
-          format: 'ipv4',
-          default: '127.0.0.1'
-        },
-        host3: {
-          format: 'ipv6',
-          default: '::1'
-        },
         port: {
           format: 'port',
           default: 8080


### PR DESCRIPTION
@zaach I think this is the right time to publish a v1.0.0 for node-convict. To justify it a bit more, let's remove some old deprecations that everyone should have got rid of long ago (in Node.js time).