### PR TITLE
Accept integer millisecond durations in string form, e.g. from env vars.

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -284,9 +284,14 @@ function coerce(k, v, schema) {
     case 'timestamp': v = moment(v).valueOf(); break;
     case 'duration':
       var split = v.split(' ');
-      // Add an "s" as the unit of measurement used in Moment
-      if (!split[1].match(/s$/)) split[1] += 's';
-      v = moment.duration(parseInt(split[0], 10), split[1]).valueOf();
+      if (split.length == 1) {
+        // It must be an integer in string form.
+        v = parseInt(v, 10);
+      } else {
+        // Add an "s" as the unit of measurement used in Moment
+        if (!split[1].match(/s$/)) split[1] += 's';
+        v = moment.duration(parseInt(split[0], 10), split[1]).valueOf();
+      }
       break;
     }
   }

--- a/test/format-tests.js
+++ b/test/format-tests.js
@@ -55,6 +55,10 @@ describe('convict formats', function() {
           format: 'duration',
           default: '5 minutes'
         },
+        duration3: {
+          format: 'duration',
+          default: '12345'
+        },
         host: {
           format: 'ipaddress',
           default: '127.0.0.1'
@@ -133,6 +137,10 @@ describe('convict formats', function() {
 
     it('must handle duration in a human readable string', function() {
       conf.get('foo.duration2').must.be(60 * 5 * 1000);
+    });
+
+    it('must handle duration in milliseconds as a string', function() {
+      conf.get('foo.duration3').must.be(12345);
     });
   });
 


### PR DESCRIPTION
This fixes the issue found by @pdehaan over in https://github.com/mozilla/fxa-auth-server/pull/978