### PR TITLE
Update .travis.yml to use sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: node_js
+
+sudo: false
+
 node_js:
   - "0.12"
   - "0.10"
+
+before_install:
+  - npm i npm@2 -g # Update to latest npm 2.x
+
 script:
+  - npm outdated --depth 0
   - npm run-script test-travis


### PR DESCRIPTION
Should fix the _"This job ran on our legacy infrastructure. Please read our docs on how to upgrade"_ message when running on Travis.

Also bumps to latest npm@2 and prints any outdated top-level deps into Travis log for fun.

r? @zaach