### PR TITLE
Test against Node.js v4.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 sudo: false
 
 node_js:
+  - "4"
   - "0.12"
   - "0.10"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 sudo: false
 
 node_js:
-  - "4"
+  - "stable"
   - "0.12"
   - "0.10"
 


### PR DESCRIPTION
It is stated "4" and not "4.0" to test against minor updates of Node.js.
Only the newest 4.x release is supported by upstream so it doesn't make
sense to test specifically on 4.0. Node now follows semver so no
breaking changes are allowed to land before Node 5.0.0.