### PR TITLE
changed import to apply and now applying config to process.env

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -197,11 +197,18 @@ function normalizeSchema (name, node, props, fullName, env, argv) {
   }
 }
 
-function importEnvironment(o) {
+function applyEnvironment(o) {
   Object.keys(o._env).forEach(function(envStr) {
     var k = o._env[envStr];
     if (process.env[envStr]) {
       o.set(k, process.env[envStr]);
+    } else {
+      try {
+        var val = o.get(k);
+        process.env[envStr] = val;
+      } catch(e) {
+        previousErrors.push(e);
+      } 
     }
   });
 }
@@ -375,7 +382,7 @@ var convict = function convict(def) {
     load: function(conf) {
       overlay(conf, this._instance, this._schema);
       // environment and arguments always overrides config files
-      importEnvironment(rv);
+      applyEnvironment(rv);
       importArguments(rv);
       return this;
     },
@@ -386,7 +393,7 @@ var convict = function convict(def) {
         overlay(cjson.load(path), self._instance);
       });
       // environment and arguments always overrides config files
-      importEnvironment(rv);
+      applyEnvironment(rv);
       importArguments(rv);
       return this;
     },
@@ -440,7 +447,7 @@ var convict = function convict(def) {
 
   rv._instance = {};
   addDefaultValues(rv._schema, rv._instance);
-  importEnvironment(rv);
+  applyEnvironment(rv);
   importArguments(rv);
 
   return rv;


### PR DESCRIPTION
Hello! I had wanted to apply the configurations, should they have `env` properties, also to the environment (`process.env`) if they didn't already exist for use.  This pull request attempts to accomplish that as succinctly as possible.  Let me know your thoughts.  Thanks.

Richard