### PR TITLE
change to apply all config to process.env, tests passing

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -197,11 +197,32 @@ function normalizeSchema (name, node, props, fullName, env, argv) {
   }
 }
 
+function applyEnvironment(o) {
+  Object.keys(o._env).forEach(function(envStr) {
+    var k = o._env[envStr];
+    var val = o.get(k);
+    if (process.env[envStr] && 
+        o._envExists[envStr] !== 'preset') {
+      if (isObj(val) && !Array.isArray(val)) {
+        val = JSON.stringify(val); 
+      }
+      process.env[envStr] = val;
+      o.set(k, process.env[envStr]);
+    } else if (!o._envExists[envStr]) {
+      process.env[envStr] = val;
+      o._envExists[envStr] = 'configset';
+    }
+  });
+}
+
 function importEnvironment(o) {
   Object.keys(o._env).forEach(function(envStr) {
     var k = o._env[envStr];
     if (process.env[envStr]) {
-      o.set(k, process.env[envStr]);
+      if (!o._envExists[envStr]) {
+        o._envExists[envStr] === 'preset'; 
+        o.set(k, process.env[envStr]);
+      }
     }
   });
 }
@@ -377,6 +398,7 @@ var convict = function convict(def) {
       // environment and arguments always overrides config files
       importEnvironment(rv);
       importArguments(rv);
+      applyEnvironment(rv);
       return this;
     },
     loadFile: function(paths) {
@@ -388,6 +410,7 @@ var convict = function convict(def) {
       // environment and arguments always overrides config files
       importEnvironment(rv);
       importArguments(rv);
+      applyEnvironment(rv);
       return this;
     },
     validate: function(options) {
@@ -434,6 +457,9 @@ var convict = function convict(def) {
   rv._env = {};
   rv._argv = {};
 
+  // To use later
+  rv._envExists = {};
+
   Object.keys(rv._def).forEach(function(k) {
     normalizeSchema(k, rv._def[k], rv._schema.properties, k, rv._env, rv._argv);
   });
@@ -442,6 +468,7 @@ var convict = function convict(def) {
   addDefaultValues(rv._schema, rv._instance);
   importEnvironment(rv);
   importArguments(rv);
+  applyEnvironment(rv);
 
   return rv;
 };


### PR DESCRIPTION
Hello! I had wanted to apply the configurations, should they have `env` properties, also to the environment (`process.env`) if they didn't already exist for use.  This pull request attempts to accomplish that.  Let me know your thoughts and feedback.  Thanks.

Richard