### PR TITLE
Recurse WITH schema when loading new objects, so type can be found

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -238,7 +238,7 @@ function overlay(from, to, schema) {
       to[k] = coerce(k, from[k], schema);
     } else {
       if (!isObj(to[k])) to[k] = {};
-      overlay(from[k], to[k]);
+      overlay(from[k], to[k], traverseSchema(schema, k));
     }
   });
 }

--- a/test/format-tests.js
+++ b/test/format-tests.js
@@ -10,6 +10,7 @@ describe('convict formats', function() {
     convict.addFormats({
       prime: {
         validate: function(val) {
+          if (typeof val !== 'number') { throw new TypeError('must be a number'); }
           function isPrime(n) {
             if (n <= 1) return false; // zero and one are not prime
             for (var i=2; i*i <= n; i++) {
@@ -123,6 +124,15 @@ describe('convict formats', function() {
   it('must be invalid', function() {
     conf.set('foo.primeNumber', 16);
     (function() { conf.validate(); }).must.throw();
+  });
+  
+  it('must coerce nested properties on load', function() {
+    conf.load({
+      foo: {
+        primeNumber: '7'
+      }
+    });
+    (function() { conf.validate(); }).must.not.throw();
   });
 
   describe('predefined formats', function() {


### PR DESCRIPTION
Verify with test

The custom validator function for primes doesn't actually require a number to operate (`isPrime('prime') === true), so I fixed that so that the test against the broken code would fail correctly before fixing the code to make the test pass...