### PR TITLE
Add a test on coerced value

### DIFF
--- a/test/format-tests.js
+++ b/test/format-tests.js
@@ -116,11 +116,21 @@ describe('convict formats', function() {
 
   });
 
-  it('must be valid', function() {
+  it('validates default schema', function() {
     (function() { conf.validate(); }).must.not.throw();
   });
 
-  it('must be invalid', function() {
+  it('validates non-coerced correct values', function() {
+    conf.set('foo.primeNumber', 7);
+    (function() { conf.validate(); }).must.not.throw();
+  });
+
+  it('validates coerced correct values', function() {
+    conf.set('foo.primeNumber', '11');
+    (function() { conf.validate(); }).must.not.throw();
+  });
+
+  it('successfully fails to validate incorrect values', function() {
     conf.set('foo.primeNumber', 16);
     (function() { conf.validate(); }).must.throw();
   });


### PR DESCRIPTION
In
https://github.com/myndzi/node-convict/commit/8a0b747be18301d6bb7cff89539186c89992af72#diff-e61fe74d74ff5118d3d4c9f47af91673R13
a contributor wanted to add a check on format that was not in line with
coercion proceedings in Convict. So the proposed PR should hopefully
make the situation clearer for contributors.