### PR TITLE
Set linting as post tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "obj_diff": "0.3.0"
   },
   "scripts": {
-    "lint": "eslint .",
-    "pretest": "npm run lint",
     "test": "mocha --check-leaks -R spec",
-    "pretest-coverage": "npm run lint",
+    "posttest": "npm run lint",
     "test-coverage": "mocha --check-leaks --require blanket -R html-cov > test/coverage.html",
-    "pretest-travis": "npm run lint",
+    "posttest-coverage": "npm run lint",
     "test-travis": "mocha --check-leaks --require blanket -R mocha-lcov-reporter | coveralls",
+    "posttest-travis": "npm run lint",
+    "lint": "eslint .",
     "clean": "rm -rf test/coverage.html"
   },
   "config": {


### PR DESCRIPTION
Potential contributors will be spared the syntax warnings until their
changes make the tests pass, and they might actually be ready to prepare
a pull request cf.
http://blog.npmjs.org/post/127671403050/testing-and-deploying-with-ordered-npm-run-scripts

I have checked that failing to conform to the linting configuration
makes the CI produce a "Build failing".