### PR TITLE
Switch back to Istanbul

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules/*
+test/coverage/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 /node_modules
-/test/coverage.html
+npm-debug.log
+/test/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_install:
   - npm i npm@2 -g # Update to latest npm 2.x
 
 script:
-  - npm run-script test-travis
+  - npm run test-ci

--- a/package.json
+++ b/package.json
@@ -21,28 +21,23 @@
     "varify": "0.1.1"
   },
   "devDependencies": {
-    "blanket": "1.1.7",
-    "coveralls": "2.11.4",
+    "coveralls": "2.11.6",
     "eslint": "1.4.3",
-    "mocha": "2.3.2",
-    "mocha-lcov-reporter": "0.0.2",
+    "istanbul": "0.4.2",
+    "mocha": "2.4.5",
+    "mocha-lcov-reporter": "1.0.0",
     "must": "0.12.0",
     "obj_diff": "0.3.0"
   },
   "scripts": {
     "test": "mocha --check-leaks -R spec",
     "posttest": "npm run lint",
-    "test-coverage": "mocha --check-leaks --require blanket -R html-cov > test/coverage.html",
+    "test-coverage": "istanbul cover _mocha -- --check-leaks test/*-tests.js",
     "posttest-coverage": "npm run lint",
-    "test-travis": "mocha --check-leaks --require blanket -R mocha-lcov-reporter | coveralls",
-    "posttest-travis": "npm run lint",
+    "test-ci": "istanbul cover _mocha -- --check-leaks test/*-tests.js && cat test/coverage/lcov.info | coveralls",
+    "posttest-ci": "npm run lint",
     "lint": "eslint .",
-    "clean": "rm -rf test/coverage.html"
-  },
-  "config": {
-    "blanket": {
-      "pattern": "lib/convict.js"
-    }
+    "clean": "rm -rf test/coverage"
   },
   "bugs": "https://github.com/mozilla/node-convict/issues",
   "license": "Apache-2.0",


### PR DESCRIPTION
These days Istanbul has the advantages that Blanket used to have and Istanbul is more actively maintained and works with up-to-date (ES6) JavaScript, while Blanket doesn't always.

Note that this commit renames the `test-travis` script into `test-ci` since this script has nothing specific to Travis and could be used with any CI accepting lcov format.