### PR TITLE
Remove `npm outdated` from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,4 @@ before_install:
   - npm i npm@2 -g # Update to latest npm 2.x
 
 script:
-  - npm outdated --depth 0
   - npm run-script test-travis


### PR DESCRIPTION
This step just slow down CI and doesn't add anything and we are commited to update all the dependencies regularly/when needed.