### PR TITLE
Speculative effort to support RegExp as a first-class format

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -243,6 +243,7 @@ function addDefaultValues(schema, c, instance) {
 }
 
 function isObj(o) { return (typeof o === 'object' && o !== null); }
+function isRegExp(r) { return Object.prototype.toString.call(r) === '[object RegExp]'; }
 
 function overlay(from, to, schema) {
   Object.keys(from).forEach(function(k) {
@@ -351,7 +352,7 @@ var convict = function convict(def) {
      * Exports all the properties (that is the keys and their current values) as JSON
      */
     getProperties: function() {
-      return JSON.parse(JSON.stringify(this._instance));
+      return this._instance;
     },
     root: deprecate.function(function() {
       return this.getProperties();
@@ -388,6 +389,7 @@ var convict = function convict(def) {
      */
     get: function(path) {
       var o = walk(this._instance, path);
+      if (isRegExp(o)) return o;
       return typeof o !== 'undefined' ?
         JSON.parse(JSON.stringify(o)) :
         void 0;
@@ -402,6 +404,7 @@ var convict = function convict(def) {
       //   FOO.properties.BAR.properties.BAZ.default
       path = (path.split('.').join('.properties.')) + '.default';
       var o = walk(this._schema.properties, path);
+      if (isRegExp(o)) return o;
       return typeof o !== 'undefined' ?
         JSON.parse(JSON.stringify(o)) :
         void 0;

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -20,7 +20,7 @@ function assert(assertion, err_msg) {
 // format can be a:
 // - predefine type, as seen below
 // - an array of enumerated values, e.g. ["production", "development", "testing"]
-// - built-in JavaScript type, i.e. Object, Array, String, Number, Boolean
+// - built-in JavaScript type, i.e. Object, Array, String, Number, Boolean, RegExp
 // - or if omitted, the Object.prototype.toString.call of the default value
 
 var types = {
@@ -98,7 +98,8 @@ var BUILT_INS_BY_NAME = {
   'Array': Array,
   'String': String,
   'Number': Number,
-  'Boolean': Boolean
+  'Boolean': Boolean,
+  'RegExp': RegExp
 };
 var BUILT_IN_NAMES = Object.keys(BUILT_INS_BY_NAME);
 var BUILT_INS = BUILT_IN_NAMES.map(function(name) {
@@ -296,6 +297,7 @@ function coerce(k, v, schema, instance) {
     case 'boolean': v = ((v === 'false') ? false : true); break;
     case 'array': v = v.split(','); break;
     case 'object': v = JSON.parse(v); break;
+    case 'regexp': v = new RegExp(v); break;
     case 'timestamp': v = moment(v).valueOf(); break;
     case 'duration':
       var split = v.split(' ');

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -10,6 +10,7 @@ const fs        = require('fs');
 const validator = require('validator');
 const moment    = require('moment');
 const minimist  = require('minimist');
+const cloneDeep = require('lodash/cloneDeep');
 
 function assert(assertion, err_msg) {
   if (!assertion) {
@@ -243,7 +244,6 @@ function addDefaultValues(schema, c, instance) {
 }
 
 function isObj(o) { return (typeof o === 'object' && o !== null); }
-function isRegExp(r) { return Object.prototype.toString.call(r) === '[object RegExp]'; }
 
 function overlay(from, to, schema) {
   Object.keys(from).forEach(function(k) {
@@ -352,7 +352,7 @@ var convict = function convict(def) {
      * Exports all the properties (that is the keys and their current values) as JSON
      */
     getProperties: function() {
-      return this._instance;
+      return cloneDeep(this._instance);
     },
     root: deprecate.function(function() {
       return this.getProperties();
@@ -389,9 +389,8 @@ var convict = function convict(def) {
      */
     get: function(path) {
       var o = walk(this._instance, path);
-      if (isRegExp(o)) return o;
       return typeof o !== 'undefined' ?
-        JSON.parse(JSON.stringify(o)) :
+        cloneDeep(o) :
         void 0;
     },
 
@@ -404,9 +403,8 @@ var convict = function convict(def) {
       //   FOO.properties.BAR.properties.BAZ.default
       path = (path.split('.').join('.properties.')) + '.default';
       var o = walk(this._schema.properties, path);
-      if (isRegExp(o)) return o;
       return typeof o !== 'undefined' ?
-        JSON.parse(JSON.stringify(o)) :
+        cloneDeep(o) :
         void 0;
     },
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,6 +12,11 @@
       "from": "json5@0.5.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
     },
+    "lodash": {
+      "version": "4.16.2",
+      "from": "lodash@4.16.2",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz"
+    },
     "minimist": {
       "version": "1.2.0",
       "from": "minimist@1.2.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "depd": "1.1.0",
     "json5": "0.5.0",
+    "lodash": "4.16.2",
     "minimist": "1.2.0",
     "moment": "2.12.0",
     "validator": "4.6.1"

--- a/test/cases/env_types.js
+++ b/test/cases/env_types.js
@@ -28,6 +28,11 @@ exports.conf = {
     format: Object,
     default: {},
     env: 'OBJECT'
+  },
+  regexp: {
+    format: RegExp,
+    default: /.*/,
+    env: 'REGEXP'
   }
 };
 
@@ -37,5 +42,6 @@ exports.env = {
   NAT: 666,
   NUM: 789.1011,
   ARRAY: 'a,b,c',
-  OBJECT: '{"foo": "bar"}'
+  OBJECT: '{"foo": "bar"}',
+  REGEXP: '^foo$'
 };

--- a/test/cases/env_types.out
+++ b/test/cases/env_types.out
@@ -4,5 +4,6 @@
   "nat": 666,
   "num": 789.1011,
   "array": ["a", "b", "c"],
-  "object": {"foo": "bar"}
+  "object": {"foo": "bar"},
+  "regexp": {}
 }

--- a/test/cases/schema-built-in-formats.json
+++ b/test/cases/schema-built-in-formats.json
@@ -18,5 +18,9 @@
   "someString": {
     "format": "String",
     "default": "foo"
+  },
+  "someRegExp": {
+    "format": "RegExp",
+    "default": ".*"
   }
 }


### PR DESCRIPTION
Not sure whether this feature will be welcomed, and I also worry that I've interfered too much with other stuff in making it work.

However, over in the FxA auth server, I'd like to both specify and get back parsed/instantiated `RegExp` objects from our config. Doing the specify bit was straightforward enough, but the getting-back part involved circumventing the explicit `JSON.stringify`-then-`JSON.parse` sanitization step that occurs before returning data.

Doing that doesn't appear to break any tests, but maybe it would still be a breaking change for some usage that I haven't thought of.

Anyway here's the change, offered more in hope than in expectation. I've added a test case for the new format and also run it against an [appropriately modified copy of the auth server config](https://github.com/mozilla/fxa-auth-server/blob/a4f59910bb8e3d52405553d2e243ba88299f402e/config/index.js#L491-L495).

r?