### PR TITLE
Use lodash.clonedeep instead of the whole lodash

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -10,7 +10,7 @@ const fs        = require('fs');
 const validator = require('validator');
 const moment    = require('moment');
 const minimist  = require('minimist');
-const cloneDeep = require('lodash/cloneDeep');
+const cloneDeep = require('lodash.clonedeep');
 
 function assert(assertion, err_msg) {
   if (!assertion) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,10 +12,10 @@
       "from": "json5@0.5.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
     },
-    "lodash": {
-      "version": "4.16.2",
-      "from": "lodash@4.16.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz"
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "from": "lodash.clonedeep@4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
     },
     "minimist": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "depd": "1.1.0",
     "json5": "0.5.0",
-    "lodash": "4.16.2",
+    "lodash.clonedeep": "4.5.0",
     "minimist": "1.2.0",
     "moment": "2.12.0",
     "validator": "4.6.1"


### PR DESCRIPTION
This is related to #165 which introduced the lodash dependency.

lodash.clonedeep is smaller than lodash and we would then only ship what we need. The lodash.clonedeep seems a little bit outdated compared to the lodash one but nothing new in lodash related to cloning since then it seems.

And finally, lodash per method packages are advertized on https://github.com/lodash/lodash

So what do you people think? I'll merge this in a week or so if there isn't anyone opposed.