### PR TITLE
Named Pipe Support

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -322,6 +322,7 @@ function coerce(k, v, schema, instance) {
     case 'nat':
     case 'integer':
     case 'int': v = parseInt(v, 10); break;
+    case 'named_pipe_or_port': v = pipe(v) ? v : parseInt(v, 10); break;
     case 'number': v = parseFloat(v); break;
     case 'boolean': v = ((v === 'false') ? false : true); break;
     case 'array': v = v.split(','); break;

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -24,6 +24,28 @@ function assert(assertion, err_msg) {
 // - built-in JavaScript type, i.e. Object, Array, String, Number, Boolean, RegExp
 // - or if omitted, the Object.prototype.toString.call of the default value
 
+
+/**
+ * Check if x is a valid port
+ *
+ * @param {String} x
+ * @returns {Boolean}
+ */
+function port(x) {
+  return validator.isInt(x) && x >= 0 && x <= 65535;
+}
+
+/**
+ * Check if x is a named pipe
+ *
+ * @see https://msdn.microsoft.com/en-us/library/windows/desktop/aa365783(v=vs.85).aspx
+ * @param {*} x
+ * @returns {Boolean}
+ */
+function pipe(x) {
+  return String(x).includes('\\\\.\\pipe\\');
+}
+
 const types = {
   '*': function() { },
   int: function(x) {
@@ -33,8 +55,15 @@ const types = {
     assert(validator.isInt(x) && x >= 0, 'must be a positive integer');
   },
   port: function(x) {
-    assert(validator.isInt(x) && x >= 0 && x <= 65535,
-          'Ports must be within range 0 - 65535');
+    assert(port(x), 'ports must be within range 0 - 65535');
+  },
+  named_pipe: function(x) {
+    assert(pipe(x), 'must be a valid pipe');
+  },
+  named_pipe_or_port: function(x) {
+    if (!pipe(x)) {
+      assert(port(x), 'must be a pipe or a number within range 0 - 65535');
+    }
   },
   url: function(x) {
     assert(validator.isURL(x), 'must be a URL');

--- a/test/format-tests.js
+++ b/test/format-tests.js
@@ -77,6 +77,14 @@ describe('convict formats', function() {
           format: 'port',
           default: 8080
         },
+        pipe: {
+          format: 'named_pipe',
+          default: '\\\\.\\pipe\\test',
+        },
+        pipe_port: {
+          format: 'named_pipe_or_port',
+          default: '\\\\.\\pipe\\pipe_port',
+        },
         email: {
           format: 'email',
           default: 'foo@bar.com'
@@ -168,6 +176,74 @@ describe('convict formats', function() {
     it('must handle duration in milliseconds as a string', function() {
       conf.get('foo.duration3').must.be(12345);
     });
+
+    describe('named_pipe_or_port', function() {
+
+      let conf = convict({
+        port: {
+          format: 'named_pipe_or_port',
+          default: '1234',
+        },
+        pipe: {
+          format: 'named_pipe_or_port',
+          default: '\\\\.\\pipe\\test',
+        },
+        to_pipe: {
+          format: 'named_pipe_or_port',
+          default: 1234,
+        },
+        to_port: {
+          format: 'named_pipe_or_port',
+          default: '\\\\.\\pipe\\default',
+        },
+      });
+
+      it('must coerce ports to integers', function() {
+        conf.get('port').must.be(1234);
+      });
+
+      it('must not coerce pipes to integers', function() {
+        conf.get('pipe').must.be('\\\\.\\pipe\\test');
+      });
+
+      it('must handle switching from port to pipe', function() {
+        conf.set('to_pipe', '\\\\.\\pipe\\changed');
+        conf.get('to_pipe').must.be('\\\\.\\pipe\\changed');
+      });
+
+      it('must handle switching from pipe to port', function() {
+        conf.set('to_port', '8080');
+        conf.get('to_port').must.be(8080);
+      });
+
+      it('must throw for invalid ports', function() {
+
+        let conf = convict({
+          invalid: {
+            format: 'named_pipe_or_port',
+            default: '235235452355',
+          },
+        });
+
+        (function() { conf.validate() }).must.throw(Error, /must be a pipe or a number within range/);
+
+      });
+
+      it('must throw for invalid pipes', function() {
+
+        let conf = convict({
+          invalid: {
+            format: 'named_pipe_or_port',
+            default: '\\.pipe\\test',
+          },
+        });
+
+        (function() { conf.validate() }).must.throw(Error, /must be a pipe or a number within range/);
+
+      });
+
+    });
+
   });
 
   it('must throw with unknown format', function() {


### PR DESCRIPTION
Adds two new formats as per #171 
 - `named_pipe`: a windows named pipe
- `named_pipe_or_port`: accepts both pipes and ports

[MSDN Documention](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365783(v=vs.85).aspx) for pipes

**Note**: coercion of `named_pipe_or_port` will fail if using `load` or `loadFile` because of #126 