### PR TITLE
Handle shorthand for default empty objects

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -146,7 +146,7 @@ const BUILT_INS = BUILT_IN_NAMES.map(function(name) {
 function normalizeSchema(name, node, props, fullName, env, argv, sensitive) {
   // If the current schema node is not a config property (has no "default"), recursively normalize it.
   if (typeof node === 'object' && node !== null && !Array.isArray(node) &&
-    !('default' in node)) {
+    Object.keys(node).length > 0 && !('default' in node)) {
     props[name] = {
       properties: {}
     };
@@ -155,7 +155,8 @@ function normalizeSchema(name, node, props, fullName, env, argv, sensitive) {
                       k, env, argv, sensitive);
     });
     return;
-  } else if (typeof node !== 'object' || Array.isArray(node) || node === null) {
+  } else if (typeof node !== 'object' || Array.isArray(node) ||
+    node === null || Object.keys(node).length == 0) {
     // Normalize shorthand "value" config properties
     node = { default: node };
   }
@@ -269,7 +270,7 @@ function addDefaultValues(schema, c, instance) {
     if (p.properties) {
       let kids = c[name] || {};
       addDefaultValues(p, kids, instance);
-      if (Object.keys(kids).length) c[name] = kids;
+      c[name] = kids;
     } else {
       c[name] = coerce(name, p.default, schema, instance);
     }

--- a/test/cases/default_shorthand.out
+++ b/test/cases/default_shorthand.out
@@ -7,5 +7,6 @@
   "object": {
     "bool": true
   },
-  "null": null
+  "null": null,
+  "emptyObject": {}
 }


### PR DESCRIPTION
As described in [this comment][comment1] and [this comment][comment2], this allows properties to be specified as defaulting to an empty object using shorthand. Example:
```javascript
'use strict';
const convict = require('convict');

let config = convict({
  empty: {}
});

config.get(); // -> { empty: {} }
config.get('empty'); // -> {}
```
I'm not positive this is necessarily something that should be supported, but it does add some consistency, which is always nice, so I figured I'd submit a patch for consideration. @madarche, please take a look when you get a chance.

[comment1]: https://github.com/mozilla/node-convict/pull/192#issuecomment-289927261
[comment2]: https://github.com/mozilla/node-convict/pull/192#issuecomment-290170301