### PR TITLE
Support arbitrary casing of booleans

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -329,7 +329,7 @@ function coerce(k, v, schema, instance) {
     case 'int': v = parseInt(v, 10); break;
     case 'port_or_windows_named_pipe': v = isWindowsNamedPipe(v) ? v : parseInt(v, 10); break;
     case 'number': v = parseFloat(v); break;
-    case 'boolean': v = ((v === 'false') ? false : true); break;
+    case 'boolean': v = (String(v).toLowerCase() !== 'false'); break;
     case 'array': v = v.split(','); break;
     case 'object': v = JSON.parse(v); break;
     case 'regexp': v = new RegExp(v); break;

--- a/test/cases/boolean.js
+++ b/test/cases/boolean.js
@@ -1,0 +1,32 @@
+'use strict';
+
+exports.conf = {
+  true: {
+    upper: {
+      format: Boolean,
+      default: null
+    },
+    lower: {
+      format: Boolean,
+      default: null
+    },
+    mixed: {
+      format: Boolean,
+      default: null
+    }
+  },
+  false: {
+    upper: {
+      format: Boolean,
+      default: null
+    },
+    lower: {
+      format: Boolean,
+      default: null
+    },
+    mixed: {
+      format: Boolean,
+      default: null
+    }
+  }
+};

--- a/test/cases/boolean.json
+++ b/test/cases/boolean.json
@@ -1,0 +1,12 @@
+{
+  "true": {
+    "upper": "TRUE",
+    "lower": "true",
+    "mixed": "True"
+  },
+  "false": {
+    "upper": "FALSE",
+    "lower": "false",
+    "mixed": "False"
+  }
+}

--- a/test/cases/boolean.out
+++ b/test/cases/boolean.out
@@ -1,0 +1,12 @@
+{
+  "true": {
+    "upper": true,
+    "lower": true,
+    "mixed": true
+  },
+  "false": {
+    "upper": false,
+    "lower": false,
+    "mixed": false
+  }
+}


### PR DESCRIPTION
This will allow, for example, `'FALSE'` to be correctly interpreted.