### PR TITLE
Make schema objects actually useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Each setting in the schema has six possible properties, each aiding in convict's
 * **Default values**:  Every setting *must* have a default value.
 * **Environmental variables**: If the variable specified by `env` has a value, it will overwrite the setting's default value. An environment variable may not be mapped to more than one setting.
 * **Command-line arguments**: If the command-line argument specified by `arg` is supplied, it will overwrite the setting's default value or the value derived from `env`.
-* **Documentation**: The `doc` property is pretty self-explanatory. The nice part about having it in the schema rather than as a comment is that we can call `conf.toSchemaString()` and have it displayed in the output.
+* **Documentation**: The `doc` property is pretty self-explanatory. The nice part about having it in the schema rather than as a comment is that we can call `conf.getSchemaString()` and have it displayed in the output.
 * **Sensitive values and secrets**: If `sensitive` is set to `true`, this value will be masked to `"[Sensitive]"` when `conf.toString()` is called. This helps avoid disclosing secret keys when printing configuration at application start for debugging purposes.
 
 Nested configuration settings are also supported:

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -160,7 +160,7 @@ function normalizeSchema(name, node, props, fullName, env, argv, sensitive) {
     node = { default: node };
   }
 
-  let o = Object.create(node);
+  let o = cloneDeep(node);
   props[name] = o;
 
   // associate this property with an environmental variable

--- a/test/cases/schema-object.js
+++ b/test/cases/schema-object.js
@@ -1,0 +1,43 @@
+'use strict';
+
+exports.conf = {
+  shorthand: 'value',
+  basic: {
+    default: true
+  },
+  doc: {
+    default: null,
+    doc: 'A value with a docstring'
+  },
+  format: {
+    default: 1,
+    format: 'nat'
+  },
+  typeFormat: {
+    default: true,
+    format: Boolean
+  },
+  env: {
+    default: '',
+    env: 'ENV'
+  },
+  arg: {
+    default: false,
+    arg: 'arg'
+  },
+  sensitive: {
+    default: 'password',
+    sensitive: true
+  },
+  combined: {
+    default: 'hello',
+    doc: 'A value with every property set',
+    format: String,
+    env: 'COMBINED',
+    arg: 'combined',
+    sensitive: false
+  },
+  nested: {
+    child: 'ababa'
+  }
+};

--- a/test/cases/schema-object.out
+++ b/test/cases/schema-object.out
@@ -1,0 +1,14 @@
+{
+  "shorthand": "value",
+  "basic": true,
+  "doc": null,
+  "format": 1,
+  "typeFormat": true,
+  "env": "",
+  "arg": false,
+  "sensitive": "password",
+  "combined": "hello",
+  "nested": {
+    "child": "ababa"
+  }
+}

--- a/test/cases/schema-object.schema
+++ b/test/cases/schema-object.schema
@@ -1,0 +1,49 @@
+{
+  "properties": {
+    "shorthand": {
+      "default": "value"
+    },
+    "basic": {
+      "default": true
+    },
+    "doc": {
+      "default": null,
+      "doc": "A value with a docstring"
+    },
+    "format": {
+      "default": 1,
+      "format": "nat"
+    },
+    "typeFormat": {
+      "default": true,
+      "format": "boolean"
+    },
+    "env": {
+      "default": "",
+      "env": "ENV"
+    },
+    "arg": {
+      "default": false,
+      "arg": "arg"
+    },
+    "sensitive": {
+      "default": "password",
+      "sensitive": true
+    },
+    "combined": {
+      "default": "hello",
+      "doc": "A value with every property set",
+      "format": "string",
+      "env": "COMBINED",
+      "arg": "combined",
+      "sensitive": false
+    },
+    "nested": {
+      "properties": {
+        "child": {
+          "default": "ababa"
+        }
+      }
+    }
+  }
+}

--- a/test/runner.js
+++ b/test/runner.js
@@ -11,7 +11,11 @@ process.on('message', function(spec) {
     if (s.formats)
       convict.addFormats(s.formats);
     let conf = convict(s.conf).loadFile(spec.config_files).validate();
-    process.send({result: conf.get(), string: conf.toString()});
+    process.send({
+      result: conf.get(),
+      string: conf.toString(),
+      schema: conf.getSchema()
+    });
     process.exit(0);
   } catch(e) {
     console.error(e); // eslint-disable-line no-console

--- a/test/schema-tests.js
+++ b/test/schema-tests.js
@@ -87,13 +87,19 @@ describe('convict schema file', function() {
         'properties': {
           'foo': {
             'properties': {
-              'bar': {},
+              'bar': {
+                'default': 7
+              },
               'baz': {
                 'properties': {
-                  'bing': {},
+                  'bing': {
+                    'default': 'foo'
+                  },
                   'name with spaces': {
                     'properties': {
-                      'name_with_underscores': {}
+                      'name_with_underscores': {
+                        'default': true
+                      }
                     }
                   }
                 }
@@ -110,13 +116,19 @@ describe('convict schema file', function() {
         'properties': {
           'foo': {
             'properties': {
-              'bar': {},
+              'bar': {
+                'default': 7
+              },
               'baz': {
                 'properties': {
-                  'bing': {},
+                  'bing': {
+                    'default': 'foo'
+                  },
                   'name with spaces': {
                     'properties': {
-                      'name_with_underscores': {}
+                      'name_with_underscores': {
+                        'default': true
+                      }
                     }
                   }
                 }

--- a/test/static-tests.js
+++ b/test/static-tests.js
@@ -16,6 +16,7 @@ files.forEach(function(f) {
     spec: f,
     output: m[1] + '.out',
     outputString: m[1] + '.string',
+    outputSchema: m[1] + '.schema',
     config_files: []
   };
 });
@@ -77,7 +78,7 @@ function run(name, done) {
         // check that configuration is what we expect
         let err = diffObjects(expected, got);
         if (err) {
-          errs.push(err);
+          errs.push(`get ${err}`);
         }
 
         if (fs.existsSync(path.join(casesDir, test.outputString))) {
@@ -85,9 +86,20 @@ function run(name, done) {
           got = JSON.parse(m.string);
           let err = diffObjects(expected, got);
           if (err) {
-            errs.push(err);
+            errs.push(`toString ${err}`);
           }
         }
+
+        if (fs.existsSync(path.join(casesDir, test.outputSchema))) {
+          expected = JSON.parse(fs.readFileSync(path.join(casesDir,
+            test.outputSchema)));
+          got = m.schema;
+          let err = diffObjects(expected, got);
+          if (err) {
+            errs.push(`getSchema ${err}`);
+          }
+        }
+
         if(errs.length > 0) {
           throw new Error(errs.join('\n'));
         }


### PR DESCRIPTION
The schema nodes were being created by passing the relevant parts of the schema definition into [`Object.create()`][Object.create], which creates a new object using its argument as a prototype. Unfortunately, [`JSON.stringify()` only includes an object's own properties][JSON.stringify]¹, i.e. the properties that are not part of its prototype. As a side effect of this, [`getSchemaString()`][getSchemaString], which returns the stringified schema object, and [`getSchema()`][getSchema], which rehydrates that and returns the resulting object, did not include any of the actual attributes of the properties defined in the schema. By changing from `Object.create()` to `cloneDeep()`, this issue is avoided.

¹ See step 6.a of abstract operation `JO(value)`, or just run the following in a Node shell:
```javascript
parent = {a: 1};
console.log(JSON.stringify(parent)); // -> {"a":1}
child = Object.create(parent);
child['b'] = 2;
console.log(JSON.stringify(child)); // -> {"b":2}
console.log(child.a); // -> 1
```

Fixes #161.

[Object.create]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create
[JSON.stringify]: https://www.ecma-international.org/ecma-262/5.1/#sec-15.12.3
[getSchemaString]: https://github.com/mozilla/node-convict/blob/v3.0.0/lib/convict.js#L415-L417
[getSchema]: https://github.com/mozilla/node-convict/blob/v3.0.0/lib/convict.js#L408-L410