### PR TITLE
Rework validate() to check for overridden parent

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -94,32 +94,102 @@ const converters = {};
 const ALLOWED_OPTION_STRICT = 'strict';
 const ALLOWED_OPTION_WARN = 'warn';
 
-function validate(instance, schema, errors,strictValidation) {
-  if(!('params_not_declared' in errors)){
-    errors.params_not_declared = [];
-  }
-  if(!('values_not_good_type' in errors)){
-    errors.values_not_good_type = [];
-  }
-  Object.keys(instance).reduce(function(previousErrors, name) {
-    let p = schema.properties[name];
-    if (strictValidation && !p){
-      previousErrors.params_not_declared.push(new Error("configuration param '"+name+"' not declared in the schema"));
-      return previousErrors;
-    }
-    if (p.properties) {
-      let kids = instance[name] || {};
-      validate(kids, p, previousErrors,strictValidation);
-    } else if (! (typeof p.default === 'undefined' &&
-                  instance[name] === p.default)) {
-      try {
-        p._format(instance[name]);
-      } catch (e) {
-        previousErrors.values_not_good_type.push(e);
+function flatten(obj, useProperties) {
+  let stack = Object.keys(obj);
+  let key;
+
+  let entries = [];
+
+  while (stack.length) {
+    key = stack.shift();
+    let val = walk(obj, key);
+    if (typeof val === 'object' && !Array.isArray(val) && val != null) {
+      if (useProperties) {
+        if ('properties' in val) {
+          val = val.properties;
+          key = key + '.properties';
+        } else {
+          entries.push([key, val]);
+          continue;
+        }
+      }
+      let subkeys = Object.keys(val);
+
+      // Don't filter out empty objects
+      if (subkeys.length > 0) {
+        subkeys.forEach(function(subkey) {
+          stack.push(key + '.' + subkey);
+        });
+        continue;
       }
     }
-    return previousErrors;
-  }, errors);
+    entries.push([key, val]);
+  }
+
+  let flattened = {};
+  entries.forEach(function(entry) {
+    let key = entry[0];
+    if (useProperties) {
+      key = key.replace(/\.properties/g, '');
+    }
+    const val = entry[1];
+    flattened[key] = val;
+  });
+
+  return flattened;
+}
+
+function validate(instance, schema, strictValidation) {
+  let errors = {
+    undeclared: [],
+    invalid_type: [],
+    missing: []
+  };
+
+  const flatInstance = flatten(instance);
+  const flatSchema = flatten(schema.properties, true);
+
+  Object.keys(flatSchema).forEach(function(name) {
+    const schemaItem = flatSchema[name];
+    let instanceItem = flatInstance[name];
+    if (!(name in flatInstance)) {
+      try {
+        if (typeof schemaItem.default === 'object' &&
+          !Array.isArray(schemaItem.default)) {
+          // Missing item may be an object with undeclared children, so try to
+          // pull it unflattened from the config instance for type validation
+          instanceItem = walk(instance, name);
+        } else {
+          throw new Error('missing');
+        }
+      } catch (e) {
+        const err = new Error("configuration param '" + name
+          + "' missing from config, did you override its parent?");
+        errors.missing.push(err);
+        return;
+      }
+    }
+    delete flatInstance[name];
+
+    if (!(typeof schemaItem.default === 'undefined' &&
+          instanceItem === schemaItem.default)) {
+      try {
+        schemaItem._format(instanceItem);
+      } catch (err) {
+        errors.invalid_type.push(err);
+      }
+    }
+
+    return;
+  });
+
+  if (strictValidation) {
+    Object.keys(flatInstance).forEach(function(name) {
+      const err = new Error("configuration param '" + name
+        + "' not declared in the schema");
+      errors.undeclared.push(err);
+    });
+  }
 
   return errors;
 }
@@ -362,29 +432,29 @@ function loadJSON(path) {
   return json5.parse(fs.readFileSync(path, 'utf-8'));
 }
 
+function walk(obj, path, initializeMissing) {
+  if (path) {
+    let ar = path.split('.');
+    while (ar.length) {
+      let k = ar.shift();
+      if (initializeMissing && obj[k] == null) {
+        obj[k] = {};
+        obj = obj[k];
+      } else if (k in obj) {
+        obj = obj[k];
+      } else {
+        throw new Error("cannot find configuration param '" + path + "'");
+      }
+    }
+  }
+
+  return obj;
+}
+
 /**
  * @returns a config object
  */
 let convict = function convict(def) {
-
-  function walk(obj, path, initializeMissing) {
-    if (path) {
-      let ar = path.split('.');
-      while (ar.length) {
-        let k = ar.shift();
-        if (initializeMissing && obj[k] == null) {
-          obj[k] = {};
-          obj = obj[k];
-        } else if (k in obj) {
-          obj = obj[k];
-        } else {
-          throw new Error("cannot find configuration param '" + path + "'");
-        }
-      }
-    }
-
-    return obj;
-  }
 
   // TODO: Rename this `rv` variable (supposedly "return value") into something
   // more meaningful.
@@ -525,9 +595,9 @@ let convict = function convict(def) {
       }
 
       options.allowed = options.allowed || ALLOWED_OPTION_WARN;
-      let errors = validate(this._instance, this._schema, [], options.allowed);
+      let errors = validate(this._instance, this._schema, options.allowed);
 
-      if (errors.values_not_good_type.length + errors.params_not_declared.length) {
+      if (errors.invalid_type.length + errors.undeclared.length + errors.missing.length) {
         let sensitive = this._sensitive;
 
         let fillErrorBuffer = function(errors) {
@@ -549,17 +619,24 @@ let convict = function convict(def) {
           return err_buf;
         };
 
-        let types_err_buf = fillErrorBuffer(errors.values_not_good_type);
-        let params_err_buf = fillErrorBuffer(errors.params_not_declared);
+        const types_err_buf = fillErrorBuffer(errors.invalid_type);
+        const params_err_buf = fillErrorBuffer(errors.undeclared);
+        const missing_err_buf = fillErrorBuffer(errors.missing);
+
+        let output_err_bufs = [types_err_buf, missing_err_buf];
 
         if (options.allowed === ALLOWED_OPTION_WARN && params_err_buf.length) {
           global.console.log('Warning: '+  params_err_buf);
         } else if (options.allowed === ALLOWED_OPTION_STRICT) {
-          types_err_buf += types_err_buf.length && params_err_buf.length ? '\n' + params_err_buf : params_err_buf;
+          output_err_bufs.push(params_err_buf);
         }
 
-        if(types_err_buf.length) {
-          throw new Error(types_err_buf);
+        let output = output_err_bufs
+          .filter(function(str) { return str.length; })
+          .join('\n');
+
+        if(output.length) {
+          throw new Error(output);
         }
 
       }

--- a/test/cases/replace_parent.js
+++ b/test/cases/replace_parent.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.conf = {
+  top: {
+    middle: {
+      leaf: 'foo',
+    }
+  }
+};

--- a/test/cases/replace_parent.json
+++ b/test/cases/replace_parent.json
@@ -1,0 +1,5 @@
+{
+  "top": {
+    "middle": true
+  }
+}

--- a/test/cases/replace_parent.out
+++ b/test/cases/replace_parent.out
@@ -1,0 +1,1 @@
+configuration param 'top.middle.leaf' missing from config, did you override its parent?


### PR DESCRIPTION
Setting a field's parent to some value will cause any children to vanish.  Validation did not detect this because validation was driven by the config instance, rather than the schema. This reworks `validate()` to use the schema itself as a source. Additionally, it adds detection for that scenario.

Fixes #193.