### PR TITLE
Fix documentation for config.loadFile()

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ config.load({
   "port": 80
 });
 ```
-### config.loadFile(file1[, file2, file3, ...])
+### config.loadFile(file or fileArray)
 
 Loads and merges one or multiple JSON configuration files into `config`.
 JSON files are loaded using `JSON5`, so they can contain comments.


### PR DESCRIPTION
The documentation implied that `config.loadFile()` takes one or more file paths as arguments. In reality, it takes exactly one argument, which can either be a file path or an array of file paths.