### PR TITLE
nested props in 'object' values are not undeclared

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -173,12 +173,11 @@ function validate(instance, schema, strictValidation) {
 
     // ignore nested keys of 'object' config params 
     if (schemaItem.format === 'object') {
-      const startsWithName = new RegExp('^' + name);
       Object.keys(flatInstance)
-        .filter(function(name) {
-          return startsWithName.test(name)
-        }).forEach(function(name) {
-          delete flatInstance[name];
+        .filter(function(key) {
+          return key.startsWith(name + '.')
+        }).forEach(function(key) {
+          delete flatInstance[key];
         });
     }
 

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -175,7 +175,7 @@ function validate(instance, schema, strictValidation) {
     if (schemaItem.format === 'object') {
       Object.keys(flatInstance)
         .filter(function(key) {
-          return key.startsWith(name + '.')
+          return key.lastIndexOf(name + '.', 0) === 0;
         }).forEach(function(key) {
           delete flatInstance[key];
         });

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -171,6 +171,18 @@ function validate(instance, schema, strictValidation) {
     }
     delete flatInstance[name];
 
+    // remove any other values corresponding to nested properties of config
+    // values that should be defined as 'object'
+    if (schemaItem.format === 'object') {
+      const startsWithName = new RegExp('^' + name);
+      Object.keys(flatInstance)
+        .filter(function(name) {
+          return startsWithName.test(name)
+        }).forEach(function(name) {
+          delete flatInstance[name];
+        });
+    }
+
     if (!(typeof schemaItem.default === 'undefined' &&
           instanceItem === schemaItem.default)) {
       try {

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -171,8 +171,7 @@ function validate(instance, schema, strictValidation) {
     }
     delete flatInstance[name];
 
-    // remove any other values corresponding to nested properties of config
-    // values that should be defined as 'object'
+    // ignore nested keys of 'object' config params 
     if (schemaItem.format === 'object') {
       const startsWithName = new RegExp('^' + name);
       Object.keys(flatInstance)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "bugs": "https://github.com/mozilla/node-convict/issues",
   "engines": {
-    "node": ">=4"
+    "node": ">=4.2"
   },
   "scripts": {
     "test": "mocha --check-leaks -R spec test/*-tests.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "bugs": "https://github.com/mozilla/node-convict/issues",
   "engines": {
-    "node": ">=4.2"
+    "node": ">=4"
   },
   "scripts": {
     "test": "mocha --check-leaks -R spec test/*-tests.js",

--- a/test/validation-tests.js
+++ b/test/validation-tests.js
@@ -140,4 +140,17 @@ describe('configuration files contain properties not declared in the schema', fu
       config.validate();
     }).must.not.throw();
   })
+  it('must not show warning for undeclared nested object values', function() {
+    (function() {
+      let config = convict({
+        object: {
+          doc: 'testing',
+          format: Object,
+          default: {}
+        }
+      });
+      config.set('object', { foo: 'bar' });
+      config.validate({ allowed: 'strict' });
+    }).must.not.throw();
+  })
 });

--- a/test/validation-tests.js
+++ b/test/validation-tests.js
@@ -140,6 +140,10 @@ describe('configuration files contain properties not declared in the schema', fu
       config.validate();
     }).must.not.throw();
   })
+});
+
+describe('setting specific values', function() {
+  const convict = require('../');
   it('must not show warning for undeclared nested object values', function() {
     (function() {
       let config = convict({

--- a/test/validation-tests.js
+++ b/test/validation-tests.js
@@ -156,5 +156,35 @@ describe('setting specific values', function() {
       config.set('object', { foo: 'bar' });
       config.validate({ allowed: 'strict' });
     }).must.not.throw();
-  })
+  });
+  it('must show warning for undeclared property names similar to nested declared property name', function() {
+    (function() {
+      let config = convict({
+        parent: {
+          object: {
+            doc: 'testing',
+            format: Object,
+            default: {}
+          }
+        },
+      });
+      config.set('parent.object', { foo: 'bar' });
+      config.set('parent_object', { foo: 'bar' });
+      config.validate({ allowed: 'strict' });
+    }).must.throw();
+  });
+  it('must show warning for undeclared property names starting with declared object properties', function() {
+    (function() {
+      let config = convict({
+        object: {
+          doc: 'testing',
+          format: Object,
+          default: {}
+        }
+      });
+      config.set('object', { foo: 'bar' });
+      config.set('objectfoo', { foo: 'bar' });
+      config.validate({ allowed: 'strict' });
+    }).must.throw();
+  });
 });


### PR DESCRIPTION
Fixes #213 

This PR modifies the validation function to ignore nested properties of values corresponding to 'object' config params - they should not be flagged as 'undeclared' because the `format: Object` directive should accept any valid object.