### PR TITLE
Ensure property defaults are not modified

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -343,7 +343,7 @@ function addDefaultValues(schema, c, instance) {
       addDefaultValues(p, kids, instance);
       c[name] = kids;
     } else {
-      c[name] = coerce(name, p.default, schema, instance);
+      c[name] = coerce(name, cloneDeep(p.default), schema, instance);
     }
   });
 }

--- a/test/schema-tests.js
+++ b/test/schema-tests.js
@@ -177,6 +177,29 @@ describe('convict schema', function() {
       it('must throw if key doesn\'t exist', function() {
         (function() { conf.default('foo.no'); }).must.throw();
       });
+
+      describe('when acting on an Object property', function() {
+        beforeEach(function() {
+          conf = convict(path.join(__dirname, 'cases/schema-built-in-formats.json'));
+        });
+
+        it('must report the default value of the property', function() {
+          conf.get('someObject').must.eql({});
+          conf.default('someObject').must.eql({});
+        });
+
+        it('must not be altered by calls to .set()', function() {
+          conf.set('someObject.five', 5);
+          conf.default('someObject').must.eql({});
+          (function() { conf.default('someObject.five'); }).must.throw();
+        });
+
+        it('must not be altered by calls to .load()', function() {
+          conf.load({someObject: {five: 5}});
+          conf.default('someObject').must.eql({});
+          (function() { conf.default('someObject.five'); }).must.throw();
+        });
+      });
     });
 
     describe('.reset()', function() {


### PR DESCRIPTION
When a property with format `Object` has a default object provided, the first time an unspecified subproperty was created (e.g. via `set()` or `load()`), it would be added to the default value. This change prevents that by cloning the default value before assigning it to the instance object.

Issue discovered in https://github.com/mozilla/node-convict/pull/215#discussion_r136152811.