### PR TITLE
resolves #222 accept args and env as parameters to convict function

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ When merging configuration values from different sources, Convict follows preced
 
 1. Default value
 2. File (`config.loadFile()`)
-3. Environment variables (only if `env` property is set)
-4. Command line arguments (only if `arg` property is set)
+3. Environment variables (only used when `env` property is set in schema; can be overridden using the `env` option of the convict function)
+4. Command line arguments (only used when `arg` property is set in schema; can be overridden using the `args` option of the convict function)
 5. Set and load calls (`config.set()` and `config.load()`)
 
 ### Configuration file additional types support
@@ -425,6 +425,13 @@ Exports the schema as JSON.
 
 Exports the schema as a JSON string.
 
+### config.getArgs()
+
+The array of process arguments (not including the launcher and application file arguments). Defaults to process.argv unless an override is specified using the args key of the second (options) argument of the convict function.
+
+### config.getEnv()
+
+The map of environment variables. Defaults to process.env unless an override is specified using the env key of the second argument (options) argument of the convict function.
 
 ## FAQ
 

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -326,18 +326,19 @@ function normalizeSchema(name, node, props, fullName, env, argv, sensitive) {
 }
 
 function importEnvironment(o) {
+  const env = o.getEnv();
   Object.keys(o._env).forEach(function(envStr) {
-    if (process.env[envStr] !== undefined) {
+    if (env[envStr] !== undefined) {
       let ks = o._env[envStr];
       ks.forEach(function(k) {
-        o.set(k, process.env[envStr]);
+        o.set(k, env[envStr]);
       });
     }
   });
 }
 
 function importArguments(o) {
-  const argv = parseArgs(process.argv.slice(2));
+  const argv = parseArgs(o.getArgs());
   Object.keys(o._argv).forEach(function(argStr) {
     let k = o._argv[argStr];
     if (argv[argStr] !== undefined) {
@@ -469,11 +470,27 @@ function walk(obj, path, initializeMissing) {
 /**
  * @returns a config object
  */
-let convict = function convict(def) {
+let convict = function convict(def, opts) {
 
   // TODO: Rename this `rv` variable (supposedly "return value") into something
   // more meaningful.
   let rv = {
+    /**
+     * Gets the array of process arguments, using the override passed to the
+     * convict function or process.argv if no override was passed.
+     */
+    getArgs: function() {
+      return (opts && opts.args) || process.argv.slice(2);
+    },
+
+    /**
+     * Gets the environment variable map, using the override passed to the
+     * convict function or process.env if no override was passed.
+     */
+    getEnv: function() {
+      return (opts && opts.env) || process.env;
+    },
+
     /**
      * Exports all the properties (that is the keys and their current values) as JSON
      */

--- a/test/schema-tests.js
+++ b/test/schema-tests.js
@@ -30,6 +30,27 @@ describe('convict schema', function() {
     })}).must.throw();
   });
 
+  it('must accept process arguments and environment variables as parameters', function() {
+    conf = convict({
+      foo: {
+        format: String,
+        default: 'DEFAULT',
+        env: 'FOO',
+        arg: 'foo',
+      },
+      bar: {
+        format: String,
+        default: 'DEFAULT',
+        env: 'BAR',
+        arg: 'bar'
+      }
+    }, { args: ['--bar', 'baz'], env: { FOO: 'foz' } });
+    conf.getArgs().must.eql(['--bar', 'baz'])
+    conf.getEnv().must.eql({ FOO: 'foz' })
+    conf.get('bar').must.be('baz');
+    conf.get('foo').must.be('foz');
+  });
+
   describe('after being parsed', function() {
 
     beforeEach(function() {


### PR DESCRIPTION
- add args and env as optional parameters to convict function
- extract process.env into getEnv() function
- extract process.argv.slice(2) into getArgs() function
- document new parameters and methods in README
- add test