### PR TITLE
Allow Multiple Schema Sources

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -463,7 +463,7 @@ function walk(obj, path, initializeMissing) {
 /**
  * @returns a config object
  */
-let convict = function convict(def) {
+let convict = function convict(...def) {
 
   // TODO: Rename this `rv` variable (supposedly "return value") into something
   // more meaningful.
@@ -652,13 +652,18 @@ let convict = function convict(def) {
       return this;
     }
   };
-
+  
+  // Construct a single definition object from one or more sources
   // If the definition is a string treat it as an external schema file
-  if (typeof def === 'string') {
-    rv._def = loadJSON(def);
-  } else {
-    rv._def = def;
-  }
+  rv._def = {};
+
+  def.forEach((source) => {
+    if (typeof source === 'string') {
+      rv._def = Object.assign(rv._def, loadJSON(source));
+    } else {
+      rv._def = Object.assign(rv._def, source);
+    }
+  });
 
   // build up current config from definition
   rv._schema = {


### PR DESCRIPTION
This kind of flexibility is useful if you want to build a wrapper around this library. For instance, it can be nice to have a pre-defined config schema with some multi-project defaults, but allow an additional config schema to be passed that is specific to a certain project.