### PR TITLE
Fix custom format object nested properties warning by checking for the item type instead of item format

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,21 @@ var config = convict({
       }
     },
     default: '3cec609c9bc601c047af917a544645c50caf8cd606806b4e0a23312441014deb'
+  },
+  name: {
+    doc: "user name",
+    format: function check (val) {
+      if (typeof val.first_name !== 'string') {
+        throw new TypeError(`first name '${val.first_name}' is not a string`);
+      }
+      if (typeof val.last_name !== 'string') {
+        throw new TypeError(`last name '${val.last_name}' is not a string`);
+      }
+    },
+    default: {
+      first_name: 'John',
+      last_name: 'Doe'
+    }
   }
 });
 ```

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -171,8 +171,8 @@ function validate(instance, schema, strictValidation) {
     }
     delete flatInstance[name];
 
-    // ignore nested keys of 'object' config params
-    if (typeof schemaItem.default === 'object') {
+    // ignore nested keys of schema 'object' properties
+    if (schemaItem.format === 'object' || typeof schemaItem.default === 'object') {
       Object.keys(flatInstance)
         .filter(function(key) {
           return key.lastIndexOf(name + '.', 0) === 0;

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -172,7 +172,7 @@ function validate(instance, schema, strictValidation) {
     delete flatInstance[name];
 
     // ignore nested keys of 'object' config params
-    if (schemaItem.format === 'object') {
+    if (typeof schemaItem.default === 'object') {
       Object.keys(flatInstance)
         .filter(function(key) {
           return key.lastIndexOf(name + '.', 0) === 0;

--- a/test/validation-tests.js
+++ b/test/validation-tests.js
@@ -188,3 +188,55 @@ describe('setting specific values', function() {
     }).must.throw();
   });
 });
+
+describe('schema contains an object property with a custom format', function() {
+  const convict = require('../');
+  it('must throw if a nested object property has an undeclared format', function() {
+    (function() {
+      const config = convict({
+        object: {
+          doc: 'testing',
+          format: 'undefinedFormat',
+          default: {
+            bar: 'baz',
+          },
+        },
+      });
+
+      config.validate({ allowed: 'strict' });
+    }).must.throw();
+  });
+  it('must not throw if an object property has a nested value and a custom format', function() {
+    (function() {
+      convict.addFormat('foo', function() {});
+      const config = convict({
+        object: {
+          doc: 'testing',
+          format: 'foo',
+          default: {
+            bar: 'baz',
+          },
+        },
+      });
+
+      config.validate({ allowed: 'strict' });
+    }).must.not.throw();
+  });
+  it('must not throw if a declared object property with a custom format and with nested values is set', function() {
+    (function() {
+      convict.addFormat('foo', function() {});
+      const config = convict({
+        object: {
+          doc: 'testing',
+          format: 'foo',
+          default: {
+            bar: 'baz',
+          },
+        },
+      });
+
+      config.set('object', { bar: '', baz: 'blah' });
+      config.validate({ allowed: 'strict' });
+    }).must.not.throw();
+  });
+});


### PR DESCRIPTION
This PR aims to improve #215 and fix #233. This works in our use-case but feel free to point out any undesired effect this might have.
  