### PR TITLE
Make deep-cloning on config.get() optional

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -510,9 +510,12 @@ let convict = function convict(def) {
      * @returns the current value of the name property. name can use dot
      *     notation to reference nested values
      */
-    get: function(path) {
+    get: function(path, options) {
+      if (!options) options = { clone: true };
+
       let o = walk(this._instance, path);
-      return cloneDeep(o);
+      if (options.clone) return cloneDeep(o);
+      return o;
     },
 
     /**

--- a/test/get-tests.js
+++ b/test/get-tests.js
@@ -51,5 +51,17 @@ describe('convict', function() {
       let val = conf.get('env');
       val.must.be('bar');
     });
+
+    it('must clone value by default', function() {
+      let val = {};
+      conf.set('someValue', val);
+      conf.get('someValue').must.not.be(val);
+    });
+
+    it('must return value reference if specified', function() {
+      let val = {};
+      conf.set('someValue', val);
+      conf.get('someValue', { clone: false }).must.be(val);
+    });
   });
 });


### PR DESCRIPTION
- Add an option on config.get() to make deepClone optional (default to true to keep backward compatibility)
```
// Usage
const val = config.get('value', { clone: false });
```