### PR TITLE
Make warnings more visible by coloring them

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -635,7 +635,14 @@ let convict = function convict(def) {
         let output_err_bufs = [types_err_buf, missing_err_buf];
 
         if (options.allowed === ALLOWED_OPTION_WARN && params_err_buf.length) {
-          global.console.log('Warning: '+  params_err_buf);
+          let warning = 'Warning:';
+          if (process.stdout.isTTY) {
+            // Write 'Warning:' in bold and in yellow
+            const SET_BOLD_YELLOW_TEXT = '\x1b[33;1m';
+            const RESET_ALL_ATTRIBUTES = '\x1b[0m';
+            warning = SET_BOLD_YELLOW_TEXT + warning + RESET_ALL_ATTRIBUTES;
+          }
+          global.console.log(warning + ' ' + params_err_buf);
         } else if (options.allowed === ALLOWED_OPTION_STRICT) {
           output_err_bufs.push(params_err_buf);
         }


### PR DESCRIPTION
Warnings are currently easy to miss because they are visually indistinguishable from other text. It would be better if we write `Warning:` in **bold** and color it in yellow, similar to deprecation warnings from the `depd` package.

* If `process.stdout` is a terminal emulator: Use [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) to switch the text weight and color to bold and yellow, write `Warning:` and switch text style back to normal.
* Otherwise: Write the string 'Warning:' as usual.

The behaviour before and after these changes is shown in the screenshots below:

#### Before this change

![before-change](https://user-images.githubusercontent.com/1393737/37112202-10c798a0-2242-11e8-8382-d0311976de92.png)

#### After this change

![2 after-change](https://user-images.githubusercontent.com/1393737/37112234-1fca49c4-2242-11e8-92fe-be194adf99ca.png)

