### PR TITLE
Enhanced file formats support

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,25 @@ When merging configuration values from different sources, Convict follows preced
 4. Command line arguments (only if `arg` property is set)
 5. Set and load calls (`config.set()` and `config.load()`)
 
+### Custom file extensions
+
+To make Convict able to parse files with custom extensions during `loadFile`, you can specify corresponding parsers associate with such extensions.
+
+```javascript
+convict.addParser({ extension: 'toml', parse: toml.parse });
+convict.addParser({ extension: ['yml', 'yaml'], parse: yaml.safeLoad });
+convict.addParser([
+  { extension: 'json', parse: JSON.parse },
+  { extension: 'json5', parse: json5.parse },
+  { extension: ['yml', 'yaml'], parse: yaml.safeLoad },
+  { extension: 'toml', parse: toml.parse }
+]);
+
+const conf = convict({ ... });
+conf.loadFile('config.toml');
+```
+
+If no supported extension is detected, loadFile will fallback to using the default json5 parser for backward compatibility.
 
 ## API
 
@@ -286,6 +305,10 @@ var config = convict({
 // or
 config = convict('/some/path/to/a/config-schema.json');
 ```
+
+### convict.addParser(parser or parserArray)
+
+Adds new parsers for custom file extensions
 
 ### config.addFormat(format)
 

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -91,7 +91,7 @@ types.integer = types.int;
 
 const converters = {};
 
-const parsers = {};
+const parsers_registry = {};
 
 const ALLOWED_OPTION_STRICT = 'strict';
 const ALLOWED_OPTION_WARN = 'warn';
@@ -440,7 +440,7 @@ function coerce(k, v, schema, instance) {
 function loadFile(path) {
   const segments = path.split('.');
   const extension = segments.length > 1 ? segments.pop() : '';
-  const parse = parsers[extension] || json5.parse;
+  const parse = parsers_registry[extension] || json5.parse;
 
   // TODO Get rid of the sync call
   // eslint-disable-next-line no-sync
@@ -726,23 +726,21 @@ convict.addFormats = function(formats) {
 /**
  * Adds a new custom file parser
  */
-convict.addParser = function(parser) {
-  if (typeof parser.parse !== 'function') throw new Error('Parse function parser.parse must be a function');
+convict.addParser = function(parsers) {
+  if (!Array.isArray(parsers)) parsers = [parsers];
 
-  let formats = [];
-  formats = formats.concat(parser.formats || parser.format);
-
-  for (let i = 0; i < formats.length; i++) {
-    parsers[formats[i]] = parser.parse;
-  }
-};
-
-/**
- * Adds new custom file parsers
- */
-convict.addParsers = function(parsers) {
   parsers.forEach(function(parser) {
-    convict.addParser(parser);
+    if (!parser) throw new Error('Invalid parser');
+    if (!parser.extension) throw new Error('Missing parser extension');
+    if (!parser.parse) throw new Error('Missing parser parse function');
+
+    if (typeof parser.parse !== 'function') throw new Error('Invalid parser.parse function');
+
+    const extensions = !Array.isArray(parser.extension) ? [parser.extension] : parser.extension;
+    extensions.forEach(function(extension) {
+      if (typeof extension !== 'string') throw new Error('Invalid parser.extension');
+      parsers_registry[extension] = parser.parse;
+    });
   });
 };
 

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -91,6 +91,8 @@ types.integer = types.int;
 
 const converters = {};
 
+const parsers = {};
+
 const ALLOWED_OPTION_STRICT = 'strict';
 const ALLOWED_OPTION_WARN = 'warn';
 
@@ -435,10 +437,14 @@ function coerce(k, v, schema, instance) {
   return v;
 }
 
-function loadJSON(path) {
+function loadFile(path) {
+  const segments = path.split('.');
+  const extension = segments.length > 1 ? segments.pop() : '';
+  const parse = parsers[extension] || json5.parse;
+
   // TODO Get rid of the sync call
   // eslint-disable-next-line no-sync
-  return json5.parse(fs.readFileSync(path, 'utf-8'));
+  return parse(fs.readFileSync(path, 'utf-8'));
 }
 
 function walk(obj, path, initializeMissing) {
@@ -580,7 +586,7 @@ let convict = function convict(def) {
       let self = this;
       if (!Array.isArray(paths)) paths = [paths];
       paths.forEach(function(path) {
-        overlay(loadJSON(path), self._instance, self._schema);
+        overlay(loadFile(path), self._instance, self._schema);
       });
       // environment and arguments always overrides config files
       importEnvironment(rv);
@@ -662,7 +668,7 @@ let convict = function convict(def) {
 
   // If the definition is a string treat it as an external schema file
   if (typeof def === 'string') {
-    rv._def = loadJSON(def);
+    rv._def = loadFile(def);
   } else {
     rv._def = def;
   }
@@ -714,6 +720,29 @@ convict.addFormat = function(name, validate, coerce) {
 convict.addFormats = function(formats) {
   Object.keys(formats).forEach(function(type) {
     convict.addFormat(type, formats[type].validate, formats[type].coerce);
+  });
+};
+
+/**
+ * Adds a new custom file parser
+ */
+convict.addParser = function(parser) {
+  if (typeof parser.parse !== 'function') throw new Error('Parse function parser.parse must be a function');
+
+  let formats = [];
+  formats = formats.concat(parser.formats || parser.format);
+
+  for (let i = 0; i < formats.length; i++) {
+    parsers[formats[i]] = parser.parse;
+  }
+};
+
+/**
+ * Adds new custom file parsers
+ */
+convict.addParsers = function(parsers) {
+  parsers.forEach(function(parser) {
+    convict.addParser(parser);
   });
 };
 

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -731,8 +731,8 @@ convict.addParser = function(parsers) {
 
   parsers.forEach(function(parser) {
     if (!parser) throw new Error('Invalid parser');
-    if (!parser.extension) throw new Error('Missing parser extension');
-    if (!parser.parse) throw new Error('Missing parser parse function');
+    if (!parser.extension) throw new Error('Missing parser.extension');
+    if (!parser.parse) throw new Error('Missing parser.parse function');
 
     if (typeof parser.parse !== 'function') throw new Error('Invalid parser.parse function');
 

--- a/package.json
+++ b/package.json
@@ -51,9 +51,11 @@
     "coveralls": "2.13.1",
     "eslint": "4.6.1",
     "istanbul": "0.4.5",
+    "js-yaml": "^3.11.0",
     "mocha": "3.5.3",
     "must": "0.13.4",
-    "obj_diff": "0.3.0"
+    "obj_diff": "0.3.0",
+    "toml": "^2.3.3"
   },
   "browserify": {
     "transform": [

--- a/test/cases/formats/data
+++ b/test/cases/formats/data
@@ -1,0 +1,4 @@
+{
+  // json5 parser should ignore this comment
+  "data": "lorem ispum"
+}

--- a/test/cases/formats/data.json
+++ b/test/cases/formats/data.json
@@ -1,0 +1,3 @@
+{
+  "data": "lorem ispum"
+}

--- a/test/cases/formats/data.json5
+++ b/test/cases/formats/data.json5
@@ -1,0 +1,4 @@
+{
+  // json5 parser should ignore this comment
+  "data": "lorem ispum"
+}

--- a/test/cases/formats/data.toml
+++ b/test/cases/formats/data.toml
@@ -1,0 +1,1 @@
+data = "lorem ispum"

--- a/test/cases/formats/data.yaml
+++ b/test/cases/formats/data.yaml
@@ -1,0 +1,2 @@
+---
+data: "lorem ispum"

--- a/test/cases/formats/out.js
+++ b/test/cases/formats/out.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  data: 'lorem ispum'
+};

--- a/test/cases/formats/schema.js
+++ b/test/cases/formats/schema.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  data: {
+    format: '*',
+    default: undefined
+  },
+};

--- a/test/loadFile-tests.js
+++ b/test/loadFile-tests.js
@@ -13,29 +13,51 @@ describe('convict', function() {
 
   describe('.addParser()', function() {
     it('must not throw on valid parser', function() {
-      (function() { convict.addParser({ formats: ['json'], parse: JSON.parse }); }).must.not.throw();
+      (function() { convict.addParser({ extension: 'json', parse: JSON.parse }); }).must.not.throw();
+      (function() { convict.addParser({ extension: ['yml', 'yaml'], parse: yaml.safeLoad }); }).must.not.throw();
     });
 
-    it('must throw on invalid parser', function() {
-      (function() { convict.addParser({ formats: ['json'], parse: 'foo' }); }).must.throw();
-    });
-  });
-
-  describe('.addParsers()', function() {
-    it('must not throw on valid parsers', function() {
+    it('must not throw on valid array of parsers', function() {
       (function() {
-        convict.addParsers([
-          { formats: ['json'], parse: JSON.parse },
-          { formats: ['json5'], parse: json5.parse }
+        convict.addParser([
+          { extension: 'json', parse: JSON.parse },
+          { extension: ['yml', 'yaml'], parse: yaml.safeLoad }
         ]);
       }).must.not.throw();
     });
 
     it('must throw on invalid parser', function() {
+      (function() { convict.addParser(undefined); }).must.throw();
+      (function() { convict.addParser(null); }).must.throw();
+    });
+
+    it('must throw on invalid parser that is missing extension', function() {
+      (function() { convict.addParser({ parse: JSON.parse }); }).must.throw();
+    });
+
+    it('must throw on invalid parser that has invalid extension', function() {
+      (function() { convict.addParser({ extension: 100, parse: JSON.parse }); }).must.throw();
+      (function() { convict.addParser({ extension: ['yml', 100], parse: yaml.parse }); }).must.throw();
+    });
+
+    it('must throw on invalid parser that is missing parse function', function() {
+      (function() { convict.addParser({ extension: 'json' }); }).must.throw();
+    });
+
+    it('must throw on invalid parser that has invalid parse function', function() {
+      (function() { convict.addParser({ extension: 'json', parse: 100 }); }).must.throw();
+    });
+
+    it('must throw on invalid array of parsers', function() {
       (function() {
-        convict.addParsers([
-          { formats: ['json'], parse: 'foo' },
-          { formats: ['json5'], parse: 'bar' }
+        convict.addParser([
+          undefined,
+          null,
+          { extension: 'json' }, // Missing parse function
+          { extension: 'json', parse: 100 }, // Invalid parse function
+          { parse: JSON.parse }, // Missing extension
+          { extension: 100, parse: JSON.parse }, // Invalid extension
+          { extension: ['yaml', 200], parse: yaml.parse }, // Invalid extension array
         ]);
       }).must.throw();
     });
@@ -51,7 +73,7 @@ describe('convict', function() {
     });
 
     it('must work with custom json parser', function() {
-      convict.addParser({ formats: ['json'], parse: JSON.parse });
+      convict.addParser({ extension: 'json', parse: JSON.parse });
 
       const conf = convict(schema);
       conf.loadFile(path.join(__dirname, 'cases/formats/data.json'));
@@ -61,7 +83,7 @@ describe('convict', function() {
     });
 
     it('must work with custom json5 parser', function() {
-      convict.addParser({ formats: ['json5'], parse: json5.parse });
+      convict.addParser({ extension: 'json5', parse: json5.parse });
 
       const conf = convict(schema);
       conf.loadFile(path.join(__dirname, 'cases/formats/data.json5'));
@@ -71,7 +93,7 @@ describe('convict', function() {
     });
 
     it('must work with custom yaml parser', function() {
-      convict.addParser({ formats: ['yml', 'yaml'], parse: yaml.safeLoad });
+      convict.addParser({ extension: ['yml', 'yaml'], parse: yaml.safeLoad });
 
       const conf = convict(schema);
       conf.loadFile(path.join(__dirname, 'cases/formats/data.yaml'));
@@ -81,7 +103,7 @@ describe('convict', function() {
     });
 
     it('must work with custom toml parser', function() {
-      convict.addParser({ formats: ['toml'], parse: toml.parse });
+      convict.addParser({ extension: 'toml', parse: toml.parse });
 
       const conf = convict(schema);
       conf.loadFile(path.join(__dirname, 'cases/formats/data.toml'));

--- a/test/loadFile-tests.js
+++ b/test/loadFile-tests.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const path = require('path');
+const json5 = require('json5');
+const yaml = require('js-yaml');
+const toml = require('toml');
+require('must');
+
+describe('convict', function() {
+  const convict = require('../');
+  const schema = require('./cases/formats/schema');
+  const expected_output = require('./cases/formats/out');
+
+  describe('.loadFile()', function() {
+    it('must work using default json5 parser if format isn\'t supported', function() {
+      const conf = convict(schema);
+      conf.loadFile(path.join(__dirname, 'cases/formats/data'));
+
+      (function() { conf.validate() }).must.not.throw();
+      conf.get().must.eql(expected_output);
+    });
+
+    it('must work with custom json parser', function() {
+      convict.addParser({ formats: ['json'], parse: JSON.parse });
+
+      const conf = convict(schema);
+      conf.loadFile(path.join(__dirname, 'cases/formats/data.json'));
+
+      (function() { conf.validate() }).must.not.throw();
+      conf.get().must.eql(expected_output);
+    });
+
+    it('must work with custom json5 parser', function() {
+      convict.addParser({ formats: ['json5'], parse: json5.parse });
+
+      const conf = convict(schema);
+      conf.loadFile(path.join(__dirname, 'cases/formats/data.json5'));
+
+      (function() { conf.validate() }).must.not.throw();
+      conf.get().must.eql(expected_output);
+    });
+
+    it('must work with custom yaml parser', function() {
+      convict.addParser({ formats: ['yml', 'yaml'], parse: yaml.safeLoad });
+
+      const conf = convict(schema);
+      conf.loadFile(path.join(__dirname, 'cases/formats/data.yaml'));
+
+      (function() { conf.validate() }).must.not.throw();
+      conf.get().must.eql(expected_output);
+    });
+
+    it('must work with custom tom parser', function() {
+      convict.addParser({ formats: ['toml'], parse: toml.parse });
+
+      const conf = convict(schema);
+      conf.loadFile(path.join(__dirname, 'cases/formats/data.toml'));
+
+      (function() { conf.validate() }).must.not.throw();
+      conf.get().must.eql(expected_output);
+    });
+  });
+});

--- a/test/loadFile-tests.js
+++ b/test/loadFile-tests.js
@@ -11,7 +11,37 @@ describe('convict', function() {
   const schema = require('./cases/formats/schema');
   const expected_output = require('./cases/formats/out');
 
-  describe('.loadFile()', function() {
+  describe('.addParser()', function() {
+    it('must not throw on valid parser', function() {
+      (function() { convict.addParser({ formats: ['json'], parse: JSON.parse }); }).must.not.throw();
+    });
+
+    it('must throw on invalid parser', function() {
+      (function() { convict.addParser({ formats: ['json'], parse: 'foo' }); }).must.throw();
+    });
+  });
+
+  describe('.addParsers()', function() {
+    it('must not throw on valid parsers', function() {
+      (function() {
+        convict.addParsers([
+          { formats: ['json'], parse: JSON.parse },
+          { formats: ['json5'], parse: json5.parse }
+        ]);
+      }).must.not.throw();
+    });
+
+    it('must throw on invalid parser', function() {
+      (function() {
+        convict.addParsers([
+          { formats: ['json'], parse: 'foo' },
+          { formats: ['json5'], parse: 'bar' }
+        ]);
+      }).must.throw();
+    });
+  });
+
+  describe('convict().loadFile()', function() {
     it('must work using default json5 parser if format isn\'t supported', function() {
       const conf = convict(schema);
       conf.loadFile(path.join(__dirname, 'cases/formats/data'));
@@ -50,7 +80,7 @@ describe('convict', function() {
       conf.get().must.eql(expected_output);
     });
 
-    it('must work with custom tom parser', function() {
+    it('must work with custom toml parser', function() {
       convict.addParser({ formats: ['toml'], parse: toml.parse });
 
       const conf = convict(schema);


### PR DESCRIPTION
Following up #236 
@madarche Are you alright with the interfaces?
Usage:
```
convict.addParser({ format: 'toml', parse: toml.parse });
convict.addParser({ formats: ['yml', 'yaml'], parse: yaml.safeLoad });
convict.addParsers([
    { format: ['json'], parse: JSON.parse },
    { formats: 'json5', parse: json5.parse }
]);
```