### PR TITLE
Handle loading empty files

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -603,7 +603,10 @@ let convict = function convict(def, opts) {
       let self = this;
       if (!Array.isArray(paths)) paths = [paths];
       paths.forEach(function(path) {
-        overlay(loadFile(path), self._instance, self._schema);
+        const from = loadFile(path);
+        if (from) {
+          overlay(from, self._instance, self._schema);
+        }
       });
       // environment and arguments always overrides config files
       importEnvironment(rv);

--- a/test/loadFile-tests.js
+++ b/test/loadFile-tests.js
@@ -119,5 +119,14 @@ describe('convict', function() {
       const conf = convict(schema);
       (function() { conf.loadFile(path.join(__dirname, 'cases/formats/data.xml')) }).must.throw(message);
     });
+	
+    it('must not break when parsing an empty file', function() {
+      convict.addParser({ extension: ['yml', 'yaml'], parse: yaml.safeLoad });
+    
+      const conf = convict(schema);
+      conf.loadFile(path.join(__dirname, 'cases/formats/data.empty.yaml'));
+    
+      (function() { conf.validate() }).must.not.throw();
+    });
   });
 });


### PR DESCRIPTION
I know this feature feels weird but, I have a file that i use to override the config quickly in development. And without that fix, I can't just comment out everything when no overrides are needed, I always need to leave at least one key defined.

fixes https://github.com/mozilla/node-convict/issues/253