### PR TITLE
Fix README for addFormats

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,9 +318,33 @@ Adds new parsers for custom file extensions
 
 Adds a new custom format.
 
-### config.addFormats(formatArray)
+### config.addFormats(formatsObject)
 
 Adds new custom formats.
+
+```javascript
+convict.addFormats({
+  {
+    name: 'float-percent',
+    validate: function(val) {
+      if (val !== 0 && (!val || val > 1 || val < 0)) {
+        throw new Error('must be a float between 0 and 1, inclusive');
+      }
+    },
+    coerce: function(val) {
+      return parseFloat(val, 10);
+    }
+  },
+  {
+    name: 'hex-string',
+    validate: function(val) {
+      if (/^[0-9a-fA-F]+$/.test(val)) {
+        throw new Error('must be a hexidecimal string');
+      }
+    }
+  }
+});
+```
 
 ### config.get(name)
 


### PR DESCRIPTION
Modify documentation of `addFormats` in `README.md`.

`README.md` used to say that the argument to `addFormats` was an `Array`, but based on my use and based on the TypeScript type definitions it appears that the argument is an `Object`.

In addition to changing the suggested type I provided an example, based on what I was able to get to work, because both `addFormat` and `addFormats` take an `Object` so it seems helpful to clarify the shape of the `Object` expected by `addFormats`.