### PR TITLE
include only required validator function

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -7,7 +7,10 @@
 
 const json5     = require('json5');
 const fs        = require('fs');
-const validator = require('validator');
+const isEmail   = require('validator/lib/isEmail');
+const isIn      = require('validator/lib/isIn');
+const isURL     = require('validator/lib/isURL');
+const isIP      = require('validator/lib/isIP');
 const moment    = require('moment');
 const parseArgs = require('yargs-parser');
 const cloneDeep = require('lodash.clonedeep');
@@ -66,13 +69,13 @@ const types = {
     }
   },
   url: function(x) {
-    assert(validator.isURL(x, {require_tld: false}), 'must be a URL');
+    assert(isURL(x, {require_tld: false}), 'must be a URL');
   },
   email: function(x) {
-    assert(validator.isEmail(x), 'must be an email address');
+    assert(isEmail(x), 'must be an email address');
   },
   ipaddress: function(x) {
-    assert(validator.isIP(x), 'must be an IP address');
+    assert(isIP(x), 'must be an IP address');
   },
   duration: function(x) {
     let err_msg = 'must be a positive integer or human readable string (e.g. 3000, "5 days")';
@@ -208,7 +211,7 @@ function validate(instance, schema, strictValidation) {
 
 // helper for asserting that a value is in the list of valid options
 function contains(options, x) {
-  assert(validator.isIn(x, options), 'must be one of the possible values: ' +
+  assert(isIn(x, options), 'must be one of the possible values: ' +
          JSON.stringify(options));
 }
 
@@ -338,7 +341,7 @@ function importEnvironment(o) {
 }
 
 function importArguments(o) {
-  const argv = parseArgs(o.getArgs(), { 
+  const argv = parseArgs(o.getArgs(), {
     configuration: {
       'dot-notation': false
     }


### PR DESCRIPTION
I was running an webpack bundle analyzer and I noticed that node-convict include all validator function. This patch change imports to include only specific functions.