### PR TITLE
Add context argument to validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,32 +44,32 @@ var convict = require('convict');
 // Define a schema
 var config = convict({
   env: {
-    doc: 'The application environment.',
-    format: ['production', 'development', 'test'],
-    default: 'development',
-    env: 'NODE_ENV'
+    doc: "The application environment.",
+    format: ["production", "development", "test"],
+    default: "development",
+    env: "NODE_ENV"
   },
   ip: {
-    doc: 'The IP address to bind.',
-    format: 'ipaddress',
-    default: '127.0.0.1',
-    env: 'IP_ADDRESS',
+    doc: "The IP address to bind.",
+    format: "ipaddress",
+    default: "127.0.0.1",
+    env: "IP_ADDRESS",
   },
   port: {
-    doc: 'The port to bind.',
-    format: 'port',
+    doc: "The port to bind.",
+    format: "port",
     default: 8080,
-    env: 'PORT',
-    arg: 'port'
+    env: "PORT",
+    arg: "port"
   },
   db: {
     host: {
-      doc: 'Database host name/IP',
+      doc: "Database host name/IP",
       format: '*',
       default: 'server1.dev.test'
     },
     name: {
-      doc: 'Database name',
+      doc: "Database name",
       format: String,
       default: 'users'
     }
@@ -263,19 +263,19 @@ convict.addFormat({
 
 const schema = {
   sources: {
-    doc: "A collection of data sources.",
+    doc: 'A collection of data sources.',
     format: 'source-array',
     default: [],
 
     children: {
       type: {
-        doc: "The source type",
-        format: ["git", "hg", "svn"],
+        doc: 'The source type',
+        format: ['git', 'hg', 'svn'],
         default: null
       },
       url: {
-        doc: "The source URL",
-        format: "url",
+        doc: 'The source URL',
+        format: 'url',
         default: null
       }
     }
@@ -283,14 +283,14 @@ const schema = {
 };
 
 convict(schema).load({
-  "sources": [
+  'sources': [
     {
-      "type": "git",
-      "url": "https://github.com/mozilla/node-convict.git"
+      'type': 'git',
+      'url': 'https://github.com/mozilla/node-convict.git'
     },
     {
-      "type": "git",
-      "url": "https://github.com/github/hub.git"
+      'type': 'git',
+      'url': 'https://github.com/github/hub.git'
     }
   ]
 }).validate();

--- a/README.md
+++ b/README.md
@@ -44,32 +44,32 @@ var convict = require('convict');
 // Define a schema
 var config = convict({
   env: {
-    doc: "The application environment.",
-    format: ["production", "development", "test"],
-    default: "development",
-    env: "NODE_ENV"
+    doc: 'The application environment.',
+    format: ['production', 'development', 'test'],
+    default: 'development',
+    env: 'NODE_ENV'
   },
   ip: {
-    doc: "The IP address to bind.",
-    format: "ipaddress",
-    default: "127.0.0.1",
-    env: "IP_ADDRESS",
+    doc: 'The IP address to bind.',
+    format: 'ipaddress',
+    default: '127.0.0.1',
+    env: 'IP_ADDRESS',
   },
   port: {
-    doc: "The port to bind.",
-    format: "port",
+    doc: 'The port to bind.',
+    format: 'port',
     default: 8080,
-    env: "PORT",
-    arg: "port"
+    env: 'PORT',
+    arg: 'port'
   },
   db: {
     host: {
-      doc: "Database host name/IP",
+      doc: 'Database host name/IP',
       format: '*',
       default: 'server1.dev.test'
     },
     name: {
-      doc: "Database name",
+      doc: 'Database name',
       format: String,
       default: 'users'
     }

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ The `coerce` function is optional.
 
 You can specify a custom format checking for array items:
 
-```
+```js
 convict.addFormat({
   name: 'source-array',
   validate: function(sources, schema) {

--- a/README.md
+++ b/README.md
@@ -243,6 +243,59 @@ var config = convict({
 
 The `coerce` function is optional.
 
+### Custom format for array items
+
+You can specify a custom format checking for array items:
+
+```
+convict.addFormat({
+  name: 'source-array',
+  validate: function(sources, schema) {
+    if (!Array.isArray(sources)) {
+      throw new Error('must be of type Array');
+    }
+
+    for (source of sources) {
+      convict(schema.children).load(source).validate();
+    }
+  }
+});
+
+const schema = {
+  sources: {
+    doc: "A collection of data sources.",
+    format: 'source-array',
+    default: [],
+
+    children: {
+      type: {
+        doc: "The source type",
+        format: ["git", "hg", "svn"],
+        default: null
+      },
+      url: {
+        doc: "The source URL",
+        format: "url",
+        default: null
+      }
+    }
+  }
+};
+
+convict(schema).load({
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://github.com/mozilla/node-convict.git"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/github/hub.git"
+    }
+  ]
+}).validate();
+```
+
 ### Coercion
 
 Convict will automatically coerce environmental variables from strings to their proper types when importing them. For instance, values with the format `int`, `nat`, `port`, or `Number` will become numbers after a straight forward `parseInt` or `parseFloat`. `duration` and `timestamp` are also parse and converted into numbers, though they utilize [moment.js](http://momentjs.com/) for date parsing.

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -314,7 +314,7 @@ function normalizeSchema(name, node, props, fullName, env, argv, sensitive) {
 
   o._format = function(x) {
     try {
-      newFormat(x);
+      newFormat(x, this);
     } catch (e) {
       // attach the value and the property's fullName to the error
       e.fullName = fullName;

--- a/test/format-tests.js
+++ b/test/format-tests.js
@@ -269,4 +269,76 @@ describe('convict formats', function() {
     let val = conf.get('foo.optional');
     expect(val).to.be(undefined);
   });
+
+  it('must return schema in second argument', function() {
+    const schema = {
+      sources: {
+        doc: "A collection of data sources.",
+        format: 'source-array',
+        default: [],
+
+        children: {
+          type: {
+            doc: "The source type",
+            format: ["git", "hg", "svn"],
+            default: null
+          },
+          url: {
+            doc: "The source URL",
+            format: "url",
+            default: null
+          }
+        }
+      }
+    };
+
+    const config = {
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/mozilla/node-convict.git"
+        },
+        {
+          "type": "git",
+          "url": "https://github.com/github/hub.git"
+        }
+      ]
+    };
+
+    const configWithError = {
+      "sources": [
+        {
+          "type": "git",
+          "url": "https:/(è_é)/github.com/mozilla/node-convict.git"
+        },
+        {
+          "type": "git",
+          "url": "https://github.com/github/hub.git"
+        }
+      ]
+    };
+
+    it('must parse a config specification', function() {
+      convict.addFormat({
+        name: 'source-array',
+        validate: function(sources, schema) {
+          if (!Array.isArray(sources)) {
+            throw new Error('must be of type Array');
+          }
+
+          for (source of sources) {
+            convict(schema.children).load(source).validate();
+          }
+        }
+      });
+    });
+
+    it('must validate children value without throw an Error', function() {
+      (() => convict(schema).load(config).validate()).must.not.throw();
+    });
+
+    it('successfully fails to validate incorrect children values', function() {
+      (() => convict(schema).load(configWithError).validate()).must.throw(Error, /url: must be a URL: value was "https:\/\(è_é\)\/github\.com\/mozilla\/node-convict\.git"/);
+    });
+  });
 });

--- a/test/format-tests.js
+++ b/test/format-tests.js
@@ -273,19 +273,19 @@ describe('convict formats', function() {
   it('must return schema in second argument', function() {
     const schema = {
       sources: {
-        doc: "A collection of data sources.",
+        doc: 'A collection of data sources.',
         format: 'source-array',
         default: [],
 
         children: {
           type: {
-            doc: "The source type",
-            format: ["git", "hg", "svn"],
+            doc: 'The source type',
+            format: ['git', 'hg', 'svn'],
             default: null
           },
           url: {
-            doc: "The source URL",
-            format: "url",
+            doc: 'The source URL',
+            format: 'url',
             default: null
           }
         }
@@ -293,27 +293,27 @@ describe('convict formats', function() {
     };
 
     const config = {
-      "sources": [
+      'sources': [
         {
-          "type": "git",
-          "url": "https://github.com/mozilla/node-convict.git"
+          'type': 'git',
+          'url': 'https://github.com/mozilla/node-convict.git'
         },
         {
-          "type": "git",
-          "url": "https://github.com/github/hub.git"
+          'type': 'git',
+          'url': 'https://github.com/github/hub.git'
         }
       ]
     };
 
     const configWithError = {
-      "sources": [
+      'sources': [
         {
-          "type": "git",
-          "url": "https:/(è_é)/github.com/mozilla/node-convict.git"
+          'type': 'git',
+          'url': 'https:/(è_é)/github.com/mozilla/node-convict.git'
         },
         {
-          "type": "git",
-          "url": "https://github.com/github/hub.git"
+          'type': 'git',
+          'url': 'https://github.com/github/hub.git'
         }
       ]
     };
@@ -326,9 +326,9 @@ describe('convict formats', function() {
             throw new Error('must be of type Array');
           }
 
-          for (source of sources) {
+          sources.forEach((source) => {
             convict(schema.children).load(source).validate();
-          }
+          })
         }
       });
     });


### PR DESCRIPTION
We can get personnel key in schema
```
convict.addFormat({
  name: 'source-array',
  validate: function(sources, schema) {
```
Doc : https://github.com/A-312/node-convict/blob/6b4e87943d3a6c47233da72334b9227c237e9dcf/README.md#custom-format-for-array-items



## Another way todo :
I hesitated to change : `newFormat(x);` to `newFormat.call(this, x);`
