### PR TITLE
Add output preference for validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,14 @@ collected and thrown or displayed at once.
    throw errors. This is to ensure that the schema and the config files are in
    sync.
 
+3. `output` : You can replace the default output `console.log`
+   by your own output function. You can use [debug module][debug] like this:
+   ```javascript
+     output: require('debug')('convict:validate:error')
+   ```
+
+[debug]: https://www.npmjs.com/package/debug
+
 ### config.getProperties()
 
 Exports all the properties (that is the keys and their current values) as JSON.

--- a/lib/convict.js
+++ b/lib/convict.js
@@ -628,6 +628,13 @@ let convict = function convict(def, opts) {
       options = options || {};
 
       options.allowed = options.allowed || ALLOWED_OPTION_WARN;
+
+      if (options.output && typeof options.output !== 'function') {
+        throw new Error('options.output is optionnal and must be a function.');
+      }
+
+      const output_function = options.output || global.console.log;
+
       let errors = validate(this._instance, this._schema, options.allowed);
 
       if (errors.invalid_type.length + errors.undeclared.length + errors.missing.length) {
@@ -666,7 +673,7 @@ let convict = function convict(def, opts) {
             const RESET_ALL_ATTRIBUTES = '\x1b[0m';
             warning = SET_BOLD_YELLOW_TEXT + warning + RESET_ALL_ATTRIBUTES;
           }
-          global.console.log(warning + ' ' + params_err_buf);
+          output_function(warning + ' ' + params_err_buf);
         } else if (options.allowed === ALLOWED_OPTION_STRICT) {
           output_err_bufs.push(params_err_buf);
         }

--- a/test/validation-tests.js
+++ b/test/validation-tests.js
@@ -84,7 +84,11 @@ describe('configuration files contain properties not declared in the schema', fu
       });
     }).must.throw();
   });
-  it('must not break when a failed validation follows an undeclared property and must display warnings', function() {
+  let message = '';
+  function myOutput(str) {
+    message += str;
+  }
+  it('must not break when a failed validation follows an undeclared property and must display warnings, and call the user output function', function() {
     (function() {
       convict.addFormat('foo', function(val) {
         if (val !== 0) { throw new Error('Validation error'); }
@@ -104,8 +108,21 @@ describe('configuration files contain properties not declared in the schema', fu
       // i don't know why. the deep nesting is also required.
       config.load({'0': true});
       config.load({ test2: { two: 'two' } });
-      config.validate();
+      config.validate({
+        output: myOutput
+      });
     }).must.throw(/Validation error/);
+  });
+  it('must use the user output function when it was declared', function() {
+    message.must.eql("\u001b[33;1mWarning:\u001b[0m configuration param '0' not declared in the schema");
+  });
+  it('must only accept function when user set an output function', function() {
+    config.loadFile(path.join(__dirname, 'cases/validation_incorrect.json'));
+    (function() {
+      config.validate({
+        output: 312
+      });
+    }).must.throw(/options\.output is optionnal and must be a function\./);
   });
   it('must not break on consecutive overrides', function() {
     (function() {


### PR DESCRIPTION
You can replace the default output `console.log` by your own output
function. You can use [debug module][debug] like this:

```javascript
config.validate({
  output: require('debug')('convict:validate:error')
})
```

[debug]: https://www.npmjs.com/package/debug