### PR TITLE
Fix dot-paths in dynamic objects

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -99,7 +99,7 @@ const ALLOWED_OPTION_STRICT = 'strict';
 const ALLOWED_OPTION_WARN = 'warn';
 
 function flatten(obj, useProperties) {
-  let stack = Object.keys(obj);
+  let stack = Object.keys(obj).map(k => [k]);
   let key;
 
   let entries = [];
@@ -111,9 +111,9 @@ function flatten(obj, useProperties) {
       if (useProperties) {
         if ('properties' in val) {
           val = val.properties;
-          key = key + '.properties';
+          key.push('properties');
         } else {
-          entries.push([key, val]);
+          entries.push([key.join('.'), val]);
           continue;
         }
       }
@@ -122,12 +122,12 @@ function flatten(obj, useProperties) {
       // Don't filter out empty objects
       if (subkeys.length > 0) {
         subkeys.forEach(function(subkey) {
-          stack.push(key + '.' + subkey);
+          stack.push(key.concat([subkey]));
         });
         continue;
       }
     }
-    entries.push([key, val]);
+    entries.push([key.join('.'), val]);
   }
 
   let flattened = {};
@@ -456,7 +456,7 @@ function loadFile(path) {
 
 function walk(obj, path, initializeMissing) {
   if (path) {
-    let ar = path.split('.');
+    let ar = Array.isArray(path) ? cloneDeep(path) : path.split('.');
     while (ar.length) {
       let k = ar.shift();
       if (initializeMissing && obj[k] == null) {

--- a/test/cases/nested_dotpath.js
+++ b/test/cases/nested_dotpath.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.conf = {
+  dynamic: { format: Object, default: null }
+};

--- a/test/cases/nested_dotpath.json
+++ b/test/cases/nested_dotpath.json
@@ -1,0 +1,5 @@
+{
+  "dynamic": {
+    "dot.path": {}
+  }
+}

--- a/test/cases/nested_dotpath.out
+++ b/test/cases/nested_dotpath.out
@@ -1,0 +1,5 @@
+{
+  "dynamic": {
+    "dot.path": {}
+  }
+}


### PR DESCRIPTION
Previously nested constructs containing dot-paths as keys would lead to
a crash like "cannot find configuration param 'dot.path'". With some
careful hacking around paths we can at least enable this use-case for
dynamic objects - it is completely untested/unsupported for regular
overlaying.