### PR TITLE
Include env var in validation error message

### DIFF
--- a/lib/convict.js
+++ b/lib/convict.js
@@ -321,6 +321,11 @@ function normalizeSchema(name, node, props, fullName, env, argv, sensitive) {
       // attach the value and the property's fullName to the error
       e.fullName = fullName;
       e.value = x;
+
+      if (o.env) {
+        e.env = o.env;
+      }
+
       throw e;
     }
   };
@@ -648,7 +653,13 @@ let convict = function convict(def, opts) {
             let e = errors[i];
 
             if (e.fullName) {
-              err_buf += e.fullName + ': ';
+              err_buf += e.fullName;
+
+              if (e.env) {
+                err_buf += '[' + e.env + ']';
+              }
+
+              err_buf += ': ';
             }
             if (e.message) err_buf += e.message;
             if (e.value && !sensitive.has(e.fullName)) {

--- a/test/cases/env_syntax.out
+++ b/test/cases/env_syntax.out
@@ -1,1 +1,1 @@
-foo.bar: must be one of the possible values: ["a","b"]: value was "c"
+foo.bar[BAR]: must be one of the possible values: ["a","b"]: value was "c"


### PR DESCRIPTION
We'd find something like this helpful for debugging validation errors on process startup, since we're mostly working with environment variables rather than config files.

Would it, or something like it, be okay to land?