### PR TITLE
Fire error with 'properties' keyname in schema and 'properties' of convict become '_cvtProperties' 

### DIFF
--- a/packages/convict/lib/convict.js
+++ b/packages/convict/lib/convict.js
@@ -202,6 +202,10 @@ const BUILT_INS = BUILT_IN_NAMES.map(function(name) {
 });
 
 function normalizeSchema(name, node, props, fullName, env, argv, sensitive) {
+  if (name === 'properties') {
+    throw new Error("'" + fullName + "': 'properties' is reserved word of convict.");
+  }
+
   // If the current schema node is not a config property (has no "default"), recursively normalize it.
   if (typeof node === 'object' && node !== null && !Array.isArray(node) &&
     Object.keys(node).length > 0 && !('default' in node)) {

--- a/packages/convict/test/cases/schema-object.schema
+++ b/packages/convict/test/cases/schema-object.schema
@@ -1,5 +1,5 @@
 {
-  "properties": {
+  "_cvtProperties": {
     "shorthand": {
       "default": "value"
     },
@@ -39,7 +39,7 @@
       "sensitive": false
     },
     "nested": {
-      "properties": {
+      "_cvtProperties": {
         "child": {
           "default": "ababa"
         }

--- a/packages/convict/test/schema-tests.js
+++ b/packages/convict/test/schema-tests.js
@@ -95,22 +95,33 @@ describe('convict schema', function() {
       }, null, 2));
     });
 
+    it('must throw if `_cvtProperties` (reserved keyword) is used', function() {
+      (function() {
+        conf = convict({
+          _cvtProperties: {
+            format: String,
+            default: 'DEFAULT'
+          }
+        });
+      }).must.throw();
+    });
+
     it('must export the schema as JSON', function() {
       let res = conf.getSchema();
       res.must.eql({
-        'properties': {
+        '_cvtProperties': {
           'foo': {
-            'properties': {
+            '_cvtProperties': {
               'bar': {
                 'default': 7
               },
               'baz': {
-                'properties': {
+                '_cvtProperties': {
                   'bing': {
                     'default': 'foo'
                   },
                   'name with spaces': {
-                    'properties': {
+                    '_cvtProperties': {
                       'name_with_underscores': {
                         'default': true
                       }
@@ -127,19 +138,19 @@ describe('convict schema', function() {
     it('must export the schema as a JSON string', function() {
       let res = conf.getSchemaString();
       res.must.eql(JSON.stringify({
-        'properties': {
+        '_cvtProperties': {
           'foo': {
-            'properties': {
+            '_cvtProperties': {
               'bar': {
                 'default': 7
               },
               'baz': {
-                'properties': {
+                '_cvtProperties': {
                   'bing': {
                     'default': 'foo'
                   },
                   'name with spaces': {
-                    'properties': {
+                    '_cvtProperties': {
                       'name_with_underscores': {
                         'default': true
                       }


### PR DESCRIPTION
fix: #318 

 - [x] Step1 : Fire error 
 - [x] Step2 : Change 'properties' keyname to `_cvtProperties`

# Q/A : 

'_cvtProperties'  should fire an error : 

> '_cvtProperties' is reserved word of convict.

```js
let conf = convict({
  ip: {
    doc: 'The IP Address to bind.',
    format: 'ipaddress',
    default: '127.0.0.1',
    env: 'IP_ADDRESS'
  },
  port: {
    doc: 'The port to bind.',
    format: 'int',
    default: 0,
    env: 'PORT'
  },
  test: {
    _cvtProperties: {
      doc: 'The port to bind.',
      format: 'int',
      default: 0,
      env: 'PORT'
    }
  }
});
```