### PR TITLE
Invert args got/expected because wrong sequence

### DIFF
--- a/test/cli-tests.js
+++ b/test/cli-tests.js
@@ -110,7 +110,7 @@ function run(name, done) {
         got = m.error.trim();
         // EOL for new line and windows support:
         expected = expected.split(require('os').EOL).join('\n');
-        require('assert').strictEqual(expected, got, `must be pass ${name}`);
+        require('assert').strictEqual(got, expected, `must be pass ${name}`);
         return done();
       }
     } catch(e) {


### PR DESCRIPTION
See the documentation of strictEqual :
> assert.strictEqual(actual, expected[, message])
https://nodejs.org/api/assert.html#assert_assert_strictequal_actual_expected_message

The expected output is : 

https://github.com/mozilla/node-convict/blob/be350a7ded016543b3eea16953be1f81c4bf34be/test/cases/argv_dot_notation.out#L1-L8
# Before : 
![image](https://user-images.githubusercontent.com/18501150/70387417-6ac7d200-19a5-11ea-8056-167a088a3bf6.png)

# Now : 
![image](https://user-images.githubusercontent.com/18501150/70387414-57b50200-19a5-11ea-9de8-7aa0aaee07c9.png)
