### PR TITLE
Update yargs-parser dependency 13.0.0 => 18.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2159,7 +2159,7 @@
       "dev": true,
       "requires": {
         "lodash.clonedeep": "4.5.0",
-        "yargs-parser": "13.0.0"
+        "yargs-parser": "18.1.1"
       }
     },
     "convict-format-with-moment": {
@@ -5736,6 +5736,16 @@
               }
             }
           }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
@@ -8066,9 +8076,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
+      "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lodash.clonedeep": "4.5.0",
     "moment": "2.24.0",
     "validator": "11.1.0",
-    "yargs-parser": "13.0.0"
+    "yargs-parser": "18.1.1"
   },
   "devDependencies": {
     "convict": "file:./packages/convict/",

--- a/packages/convict/package-lock.json
+++ b/packages/convict/package-lock.json
@@ -219,7 +219,7 @@
       "version": "file:../convict-format-with-validator",
       "dev": true,
       "requires": {
-        "validator": "10.11.0"
+        "validator": "11.1.0"
       },
       "dependencies": {
         "validator": {
@@ -1603,9 +1603,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
+      "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/packages/convict/package.json
+++ b/packages/convict/package.json
@@ -34,7 +34,7 @@
   "main": "lib/convict.js",
   "dependencies": {
     "lodash.clonedeep": "4.5.0",
-    "yargs-parser": "13.0.0"
+    "yargs-parser": "18.1.1"
   },
   "devDependencies": {
     "convict-format-with-moment": "file:../convict-format-with-moment",


### PR DESCRIPTION
According to Snyk, yargs-parser 13.0.0 has a medium security error:
https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381

fix https://github.com/mozilla/node-convict/issues/360