### PR TITLE
FIX string parsing issue of number format

### DIFF
--- a/packages/convict/src/main.js
+++ b/packages/convict/src/main.js
@@ -42,6 +42,24 @@ function isWindowsNamedPipe(x) {
   return String(x).includes('\\\\.\\pipe\\')
 }
 
+/**
+ * Checks if x is a number
+ *
+ * @param {*} x
+ * @returns {Boolean}
+ */
+function isNumber(x) {
+  if (typeof x === 'number') {
+    return true
+  } else if (parseFloat(x)) {
+    return true
+  } else if (typeof x === 'string' && x === 'NaN') {
+    return true
+  }
+
+  return false
+}
+
 const types = {
   '*': function() { },
   int: function(x) {
@@ -406,7 +424,7 @@ function coerce(k, v, schema, instance) {
     case 'integer':
     case 'int': v = parseInt(v, 10); break
     case 'port_or_windows_named_pipe': v = isWindowsNamedPipe(v) ? v : parseInt(v, 10); break
-    case 'number': v = parseFloat(v); break
+    case 'number': v = isNumber(v) ? parseFloat(v) : v; break
     case 'boolean': v = String(v).toLowerCase() !== 'false'; break
     case 'array': v = v.split(','); break
     case 'object': v = JSON.parse(v); break


### PR DESCRIPTION
While I was using convict in a project, I realized that number format validation does not work properly. When you set a string value (other than the values that can be parse to number) to a number field, convict should throw a validation error but it does not. That's why, I added an isNumber function to fix this issue. 

By the way, I am not totally sure about the scope of number format. That's why I estimated NaN and Infinity values as truthy values because of their data types. If NaN and Infinity values are not valid options for number format, I can update the function by taking that into consideration.

You can reproduce the issue by using the code below
```
const convict = require('convict')

const config = convict({
  number: {
    format: Number,
    default: 53,
  },
})

config.load({number: 'convict'})
config.validate({strict: true})

console.log('number: ', config.get('number')) // number: NaN
```