### PR TITLE
Implementation of a new feature: support loading of map like objects

### DIFF
--- a/packages/convict/src/main.js
+++ b/packages/convict/src/main.js
@@ -356,7 +356,7 @@ function isObj(o) {
 function overlay(from, to, schema) {
   Object.keys(from).forEach(function(k) {
     // leaf
-    if (Array.isArray(from[k]) || !isObj(from[k]) || !schema || schema.format === 'object') {
+    if (Array.isArray(from[k]) || !isObj(from[k]) || !schema || schema.format === 'object' || schema.children != null) {
       to[k] = coerce(k, from[k], schema)
     } else {
       if (!isObj(to[k])) {


### PR DESCRIPTION
**Implementation of a new feature: support loading of map like objects**
```
For example: 
  var config = {
    myMap: {
      someArbitraryKey:    { schemaBoundProp: 'asdf', anotherSchemaBoundProp: 'qwer'},
      anotherArbitraryKey: { schemaBoundProp: 'zxcv', anotherSchemaBoundProp: 'vbnm'}
    }
  }

  convict.addFormat({
    name: `map`,
    validate: function (theMap, schema) {
      if (typeof theMap !== 'object' || theMap == null) {
        throw new Error('must be an non-empty (map like) object')
      }
      // iterate each key in the map 
      for (const key of Object.keys(theMap)) {
        // perform validation on the key's value against the child schema
        convict(schema.children).load(theMap[key]).validate()
      }
    }
  })

  const schema = {
    myMap: {
      doc: 'this is a key value map, where the value object can be validated by a child schema',
      default: {},
      format: 'map',
      children: {
        schemaBoundProp: {
          doc: 'a property of the value object',
          default: null,
          format: String
        }, 
        anotherSchemaBoundProp: {
          doc: 'a property of the value object',
          default: null,
          format: String
        }
      }
    }
  }

  convict(schema).load(config).validate()
```

CHANGES made ->  one line change to the overlay function