### PR TITLE
Add conf.toJson() method

### DIFF
--- a/packages/convict/README.md
+++ b/packages/convict/README.md
@@ -166,7 +166,7 @@ convict's goal of being more robust and collaborator friendly.
 * **Environmental variables**: If the variable specified by `env` has a value, it will overwrite the setting's default value. An environment variable may not be mapped to more than one setting.
 * **Command-line arguments**: If the command-line argument specified by `arg` is supplied, it will overwrite the setting's default value or the value derived from `env`.
 * **Documentation**: The `doc` property is pretty self-explanatory. The nice part about having it in the schema rather than as a comment is that we can call `config.getSchemaString()` and have it displayed in the output.
-* **Sensitive values and secrets**: If `sensitive` is set to `true`, this value will be masked to `"[Sensitive]"` when `config.toString()` is called. This helps avoid disclosing secret keys when printing configuration at application start for debugging purposes.
+* **Sensitive values and secrets**: If `sensitive` is set to `true`, this value will be masked to `"[Sensitive]"` when `config.toString()` or `config.toJson()` is called. This helps avoid disclosing secret keys when printing configuration at application start for debugging purposes.
 * **Null values**: If `nullable` is set to `true`, the value counts as valid not only if it matches the specified `format`, but also when it is `null`.
 
 
@@ -584,6 +584,12 @@ collected and thrown or displayed at once.
 ### config.getProperties()
 
 Exports all the properties (that is the keys and their current values) as JSON.
+
+### config.toJson()
+
+Exports all the properties (that is the keys and their current values) as a JSON
+object, with sensitive values masked. Sensitive values are masked even if they
+aren't set, to avoid revealing any information.
 
 ### config.toString()
 

--- a/packages/convict/src/main.js
+++ b/packages/convict/src/main.js
@@ -484,10 +484,10 @@ const convict = function convict(def, opts) {
 
     /**
      * Exports all the properties (that is the keys and their current values) as
-     * a JSON string, with sensitive values masked. Sensitive values are masked
+     * a JSON object, with sensitive values masked. Sensitive values are masked
      * even if they aren't set, to avoid revealing any information.
      */
-    toString: function() {
+    toJson: function() {
       const clone = cloneDeep(this._instance)
       this._sensitive.forEach(function(key) {
         const path = key.split('.')
@@ -496,7 +496,16 @@ const convict = function convict(def, opts) {
         const parent = walk(clone, parentKey)
         parent[childKey] = '[Sensitive]'
       })
-      return JSON.stringify(clone, null, 2)
+      return clone
+    },
+
+    /**
+     * Exports all the properties (that is the keys and their current values) as
+     * a JSON string, with sensitive values masked. Sensitive values are masked
+     * even if they aren't set, to avoid revealing any information.
+     */
+    toString: function() {
+      return JSON.stringify(this.toJson(), null, 2)
     },
 
     /**

--- a/packages/convict/test/schema.test.js
+++ b/packages/convict/test/schema.test.js
@@ -102,6 +102,21 @@ describe('convict schema', function() {
       }, null, 2))
     })
 
+    test('must export all its properties as a json object', function() {
+      const res = conf.toJson()
+      expect(res).toEqual({
+        foo: {
+          bar: 7,
+          baz: {
+            bing: 'foo',
+            'name with spaces': {
+              name_with_underscores: true
+            }
+          }
+        }
+      })
+    })
+
     test('must throw if `_cvtProperties` (reserved keyword) is used', function() {
       expect(function() {
         conf = convict({


### PR DESCRIPTION
Resolves #406 

It simply uses the implementation of `toString`, including the sensitivity-censoring. Also, it changes `toString` to use `toJson` to keep it more dry. 

A test is added too.