### PR TITLE
chore: Adding browser field in package.json from convict package

### DIFF
--- a/packages/convict/package.json
+++ b/packages/convict/package.json
@@ -35,5 +35,9 @@
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
     "yargs-parser": "^20.2.7"
+  },
+  "browser": {
+    "fs": false,
+    "yargs-parser": "./node_modules/yargs-parser/browser.js"
   }
 }


### PR DESCRIPTION
The browser field can be used as a hint for bundlers when bundling for web environment 